### PR TITLE
Fix/native orientation locker by allowing custom fields on MainActivity (android) and AppDelegate (ios)

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,8 @@
     "write-json-webpack-plugin": "1.1.0",
     "babel-plugin-module-resolver": "3.2.0",
     "xcode": "2.0.0",
-    "deepmerge": "3.2.0"
+    "deepmerge": "3.2.0",
+    "react-native-orientation-locker": "1.1.5"
   },
   "optionalDependencies": {
     "ios-deploy": "1.9.4"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "test": "jest",
     "preversion": "npm run test",
     "version": "./rnv/utils/update-versions.sh",
-    "doc": "doctoc . --maxlevel 1"
+    "doc": "doctoc . --maxlevel 1",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "babel-polyfill": "6.26.0",

--- a/projectConfig/plugins.json
+++ b/projectConfig/plugins.json
@@ -10,6 +10,40 @@
         "path": "node_modules/react-native-gesture-handler/android",
         "package": "com.swmansion.gesturehandler.react.RNGestureHandlerPackage"
       }
+    },
+    "react-native-orientation-locker": {
+      "version": "1.1.5",
+      "ios": {
+        "podName": "react-native-orientation-locker",
+        "appDelegateImports": [
+          "react_native_orientation_locker"
+        ],
+        "appDelegateMethods": [
+          "func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {",
+          "  return Orientation.getOrientation();",
+          "}"
+        ]
+      },
+      "tvos": {
+        "podName": "react-native-orientation-locker"
+      },
+      "android": {
+        "package": "org.wonday.orientation.OrientationPackage",
+        "activityImports": [
+          "android.content.res.Configuration"
+        ],
+        "activityMethods": [
+          "override fun onConfigurationChanged(newConfig:Configuration) {",
+          "  super.onConfigurationChanged(newConfig)",
+          "  val intent = Intent(\"onConfigurationChanged\")",
+          "  intent.putExtra(\"newConfig\", newConfig)",
+          "  this.sendBroadcast(intent)",
+          "}"
+        ]
+      },
+      "androidtv": {
+        "package": "org.wonday.orientation.OrientationPackage"
+      }
     }
   }
 }

--- a/rnv-cli/platformTemplates/android/app/src/main/java/rnv/MainActivity.kt
+++ b/rnv-cli/platformTemplates/android/app/src/main/java/rnv/MainActivity.kt
@@ -2,10 +2,14 @@ package {{APPLICATION_ID}}
 
 import android.content.Intent
 import com.facebook.react.ReactActivity
+{{PLUGIN_ACTIVITY_IMPORTS}}
+
 /**
  * Created by paveljacko on 24/07/2018.
  */
 
 class MainActivity : ReactActivity() {
     override fun getMainComponentName(): String? = "App"
+
+    {{PLUGIN_ACTIVITY_METHODS}}
 }

--- a/rnv-cli/platformTemplates/ios/RNVApp/AppDelegate.swift
+++ b/rnv-cli/platformTemplates/ios/RNVApp/AppDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 import CoreData
 import React
 import UserNotifications
-{{APPDELEGATE_IMPORTS}}
+{{APPDELEGATE_IMPORTS}}<-
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {

--- a/rnv-cli/platformTemplates/ios/RNVApp/AppDelegate.swift
+++ b/rnv-cli/platformTemplates/ios/RNVApp/AppDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 import CoreData
 import React
 import UserNotifications
-{{APPDELEGATE_IMPORTS}}<-
+{{APPDELEGATE_IMPORTS}}
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {

--- a/rnv-cli/platformTemplates/ios/RNVApp/AppDelegate.swift
+++ b/rnv-cli/platformTemplates/ios/RNVApp/AppDelegate.swift
@@ -10,6 +10,7 @@ import UIKit
 import CoreData
 import React
 import UserNotifications
+{{APPDELEGATE_IMPORTS}}
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
@@ -40,4 +41,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         return true
     }
+
+    {{APPDELEGATE_METHODS}}
 }

--- a/rnv-cli/pluginTemplates/plugins.json
+++ b/rnv-cli/pluginTemplates/plugins.json
@@ -227,7 +227,7 @@
       "version": "1.1.5",
       "ios": {
         "podName": "react-native-orientation-locker",
-        "appDelegateImport": ["react_native_orientation_locker"],
+        "appDelegateImports": ["react_native_orientation_locker"],
         "appDelegateMethods": [
           "func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {",
           "  return Orientation.getOrientation();",

--- a/rnv-cli/pluginTemplates/plugins.json
+++ b/rnv-cli/pluginTemplates/plugins.json
@@ -224,7 +224,7 @@
       "androidtv": { "package": "com.rt2zz.reactnativecontacts.ReactNativeContacts"}
     },
     "react-native-orientation-locker" : {
-      "version": "1.1.3",
+      "version": "1.1.5",
       "ios": { "podName": "react-native-orientation-locker" },
       "tvos": { "podName": "react-native-orientation-locker" },
       "android": {

--- a/rnv-cli/pluginTemplates/plugins.json
+++ b/rnv-cli/pluginTemplates/plugins.json
@@ -227,7 +227,18 @@
       "version": "1.1.3",
       "ios": { "podName": "react-native-orientation-locker" },
       "tvos": { "podName": "react-native-orientation-locker" },
-      "android": { "package": "org.wonday.orientation.OrientationPackage"},
+      "android": {
+        "package": "org.wonday.orientation.OrientationPackage",
+        "activityImports": ["android.content.res.Configuration"],
+        "activityMethods": [
+          "override fun onConfigurationChanged(newConfig:Configuration) {",
+          "  super.onConfigurationChanged(newConfig)",
+          "  val intent = Intent(\"onConfigurationChanged\")",
+          "  intent.putExtra(\"newConfig\", newConfig)",
+          "  this.sendBroadcast(intent)",
+          "}"
+        ]
+      },
       "androidtv": { "package": "org.wonday.orientation.OrientationPackage"}
     },
     "react-native-reanimated" : {

--- a/rnv-cli/pluginTemplates/plugins.json
+++ b/rnv-cli/pluginTemplates/plugins.json
@@ -225,7 +225,15 @@
     },
     "react-native-orientation-locker" : {
       "version": "1.1.5",
-      "ios": { "podName": "react-native-orientation-locker" },
+      "ios": {
+        "podName": "react-native-orientation-locker",
+        "appDelegateImport": ["react_native_orientation_locker"],
+        "appDelegateMethods": [
+          "func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {",
+          "  return Orientation.getOrientation();",
+          "}"
+        ]
+      },
       "tvos": { "podName": "react-native-orientation-locker" },
       "android": {
         "package": "org.wonday.orientation.OrientationPackage",

--- a/rnv-cli/src/platformTools/android.js
+++ b/rnv-cli/src/platformTools/android.js
@@ -332,6 +332,7 @@ const configureGradleProject = (c, platform) => new Promise((resolve, reject) =>
 });
 
 const _injectPlugin = (c, plugin, key, pkg, pluginConfig) => {
+    logTask(`injecting plugin ${key}`);
     const className = pkg ? pkg.split('.').pop() : null;
     let packageParams = '';
     if (plugin.packageParams) {

--- a/rnv-cli/src/platformTools/android.js
+++ b/rnv-cli/src/platformTools/android.js
@@ -332,7 +332,6 @@ const configureGradleProject = (c, platform) => new Promise((resolve, reject) =>
 });
 
 const _injectPlugin = (c, plugin, key, pkg, pluginConfig) => {
-    logTask(`injecting plugin ${key}`);
     const className = pkg ? pkg.split('.').pop() : null;
     let packageParams = '';
     if (plugin.packageParams) {

--- a/rnv-cli/src/platformTools/android.js
+++ b/rnv-cli/src/platformTools/android.js
@@ -360,6 +360,17 @@ const _injectPlugin = (c, plugin, key, pkg, pluginConfig) => {
             }
         }
     }
+    if (plugin.activityImports instanceof Array) {
+        plugin.activityImports.forEach((activityImport) => {
+            // Avoid duplicate imports
+            if (pluginConfig.pluginActivityImports.indexOf(activityImport) === -1) {
+                pluginConfig.pluginActivityImports += `import ${activityImport}\n`;
+            }
+        });
+    }
+    if (plugin.activityMethods instanceof Array) {
+        pluginConfig.pluginActivityMethods += `${plugin.activityMethods.join('\n    ')}`;
+    }
     if (pkg) pluginConfig.pluginImports += `import ${pkg}\n`;
     if (className) pluginConfig.pluginPackages += `${className}(${packageParams}),\n`;
 
@@ -423,8 +434,11 @@ const configureProject = (c, platform) => new Promise((resolve, reject) => {
     const pluginPackages = 'MainReactPackage(),\n';
     const pluginImplementations = '';
     const pluginAfterEvaluate = '';
+    const pluginActivityImports = '';
+    const pluginActivityMethods = '';
     const pluginConfig = {
         pluginIncludes, pluginPaths, pluginImports, pluginPackages, pluginImplementations, pluginAfterEvaluate,
+        pluginActivityImports, pluginActivityMethods,
     };
     // PLUGINS
     if (c.appConfigFile && c.pluginConfig) {
@@ -501,6 +515,8 @@ const configureProject = (c, platform) => new Promise((resolve, reject) => {
         path.join(appFolder, activityPath),
         [
             { pattern: '{{APPLICATION_ID}}', override: getAppId(c, platform) },
+            { pattern: '{{PLUGIN_ACTIVITY_IMPORTS}}', override: pluginConfig.pluginActivityImports },
+            { pattern: '{{PLUGIN_ACTIVITY_METHODS}}', override: pluginConfig.pluginActivityMethods },
         ]);
 
     const applicationPath = 'app/src/main/java/rnv/MainApplication.kt';

--- a/rnv-cli/src/platformTools/apple.js
+++ b/rnv-cli/src/platformTools/apple.js
@@ -361,9 +361,12 @@ const _postConfigureProject = (c, platform, appFolder, appFolderName, isBundled 
     if (c.appConfigFile && c.pluginConfig) {
         const includedPlugins = c.appConfigFile.common.includedPlugins;
         const excludedPlugins = c.appConfigFile.common.excludedPlugins;
+        logTask(`c.pluginConfig`);
         if (includedPlugins) {
+            logTask(`includedPlugins`);
             const plugins = c.pluginConfig.plugins;
             for (const key in plugins) {
+                logTask(`key ${key}`);
                 if (includedPlugins.includes('*') || includedPlugins.includes(key)) {
                     const plugin = plugins[key][platform];
                     if (plugin) {

--- a/rnv-cli/src/platformTools/apple.js
+++ b/rnv-cli/src/platformTools/apple.js
@@ -339,7 +339,7 @@ const _injectPlugin = (c, plugin, key, pkg, pluginConfig) => {
 }
 
 const _postConfigureProject = (c, platform, appFolder, appFolderName, isBundled = false, ip = 'localhost', port = 8081) => new Promise((resolve, reject) => {
-    logTask(`!_postConfigureProject:${platform}:${ip}:${port}`);
+    logTask(`_postConfigureProject:${platform}:${ip}:${port}`);
     const appDelegate = 'AppDelegate.swift';
 
     const entryFile = getEntryFile(c, platform);
@@ -357,14 +357,12 @@ const _postConfigureProject = (c, platform, appFolder, appFolderName, isBundled 
     const pluginConfig = {
         pluginAppDelegateImports, pluginAppDelegateMethods,
     };
-    logTask(`c.pluginConfig ${c.pluginConfig} c.appConfigFile ${c.appConfigFile}`);
     // PLUGINS
     if (c.appConfigFile && c.pluginConfig) {
         const includedPlugins = c.appConfigFile.common.includedPlugins;
         const excludedPlugins = c.appConfigFile.common.excludedPlugins;
-        logTask(`c.pluginConfig`);
         if (includedPlugins) {
-            logTask(`includedPlugins`);
+            logTask(`includedPlugins ${JSON.stringify(c.pluginConfig.plugins)}`);
             const plugins = c.pluginConfig.plugins;
             for (const key in plugins) {
                 logTask(`key ${key}`);

--- a/rnv-cli/src/platformTools/apple.js
+++ b/rnv-cli/src/platformTools/apple.js
@@ -335,9 +335,7 @@ const _injectPlugin = (c, plugin, key, pkg, pluginConfig) => {
             }
         });
     }
-    logTask('appDelegateMethods add')
     if (plugin.appDelegateMethods instanceof Array) {
-        logTask('appDelegateMethods add ok')
         pluginConfig.pluginAppDelegateMethods += `${plugin.appDelegateMethods.join('\n    ')}`;
     }
 }
@@ -380,9 +378,6 @@ const _postConfigureProject = (c, platform, appFolder, appFolderName, isBundled 
         }
     }
 
-    logTask(`pluginConfig.pluginAppDelegateImports ${pluginConfig.pluginAppDelegateImports}`);
-    logTask(`pluginConfig.pluginAppDelegateMethods ${pluginConfig.pluginAppDelegateMethods}`);
-
     writeCleanFile(path.join(getAppTemplateFolder(c, platform), appFolderName, appDelegate),
         path.join(appFolder, appFolderName, appDelegate),
         [
@@ -391,7 +386,7 @@ const _postConfigureProject = (c, platform, appFolder, appFolderName, isBundled 
             { pattern: '{{IP}}', override: ip },
             { pattern: '{{PORT}}', override: port },
             { pattern: '{{APPDELEGATE_IMPORTS}}', override: pluginConfig.pluginAppDelegateImports },
-            { pattern: '{{APPDELEGATE_METHODS}}', override: 'IM A METHOD' },
+            { pattern: '{{APPDELEGATE_METHODS}}', override: pluginConfig.pluginAppDelegateMethods },
         ]);
 
     writeCleanFile(path.join(appTemplateFolder, 'exportOptions.plist'),

--- a/rnv-cli/src/platformTools/apple.js
+++ b/rnv-cli/src/platformTools/apple.js
@@ -357,6 +357,7 @@ const _postConfigureProject = (c, platform, appFolder, appFolderName, isBundled 
     const pluginConfig = {
         pluginAppDelegateImports, pluginAppDelegateMethods,
     };
+    logTask(`c.pluginConfig ${c.pluginConfig} c.appConfigFile ${c.appConfigFile}`);
     // PLUGINS
     if (c.appConfigFile && c.pluginConfig) {
         const includedPlugins = c.appConfigFile.common.includedPlugins;

--- a/rnv-cli/src/platformTools/apple.js
+++ b/rnv-cli/src/platformTools/apple.js
@@ -325,7 +325,6 @@ const configureXcodeProject = (c, platform, ip, port) => new Promise((resolve, r
 });
 
 const _injectPlugin = (c, plugin, key, pkg, pluginConfig) => {
-    logTask(`injecting plugin ${key} ${plugin.appDelegateImports && plugin.appDelegateImports.length} ${plugin.appDelegateMethods && plugin.appDelegateMethods.length}`);
     if (plugin.appDelegateImports instanceof Array) {
         plugin.appDelegateImports.forEach((appDelegateImport) => {
             // Avoid duplicate imports
@@ -363,10 +362,8 @@ const _postConfigureProject = (c, platform, appFolder, appFolderName, isBundled 
         const includedPlugins = c.appConfigFile.common.includedPlugins;
         const excludedPlugins = c.appConfigFile.common.excludedPlugins;
         if (includedPlugins) {
-            logTask(`includedPlugins ${JSON.stringify(c.pluginConfig.plugins)}`);
             const plugins = c.pluginConfig.plugins;
             for (const key in plugins) {
-                logTask(`key ${key}`);
                 if (includedPlugins.includes('*') || includedPlugins.includes(key)) {
                     const plugin = plugins[key][platform];
                     if (plugin) {
@@ -380,7 +377,7 @@ const _postConfigureProject = (c, platform, appFolder, appFolderName, isBundled 
     }
 
     logTask(`pluginConfig.pluginAppDelegateImports ${pluginConfig.pluginAppDelegateImports}`);
-    logTask(`pluginConfig.pluginAppDelegateImports ${pluginConfig.pluginAppDelegateMethods}`);
+    logTask(`pluginConfig.pluginAppDelegateMethods ${pluginConfig.pluginAppDelegateMethods}`);
 
     writeCleanFile(path.join(getAppTemplateFolder(c, platform), appFolderName, appDelegate),
         path.join(appFolder, appFolderName, appDelegate),

--- a/rnv-cli/src/platformTools/apple.js
+++ b/rnv-cli/src/platformTools/apple.js
@@ -325,7 +325,7 @@ const configureXcodeProject = (c, platform, ip, port) => new Promise((resolve, r
 });
 
 const _injectPlugin = (c, plugin, key, pkg, pluginConfig) => {
-    logTask(`injecting plugin ${key}`);
+    logTask(`injecting plugin ${key} ${plugin.appDelegateImports && plugin.appDelegateImports.length} ${plugin.appDelegateMethods && plugin.appDelegateMethods.length}`);
     if (plugin.appDelegateImports instanceof Array) {
         plugin.appDelegateImports.forEach((appDelegateImport) => {
             // Avoid duplicate imports

--- a/rnv-cli/src/platformTools/apple.js
+++ b/rnv-cli/src/platformTools/apple.js
@@ -389,8 +389,8 @@ const _postConfigureProject = (c, platform, appFolder, appFolderName, isBundled 
             { pattern: '{{ENTRY_FILE}}', override: entryFile },
             { pattern: '{{IP}}', override: ip },
             { pattern: '{{PORT}}', override: port },
-            { pattern: '{{APPDELEGATE_IMPORTS}}', override: port },
-            { pattern: '{{APPDELEGATE_METHODS}}', override: port },
+            { pattern: '{{APPDELEGATE_IMPORTS}}', override: pluginConfig.pluginAppDelegateImports },
+            { pattern: '{{APPDELEGATE_METHODS}}', override: pluginConfig.pluginAppDelegateMethods },
         ]);
 
     writeCleanFile(path.join(appTemplateFolder, 'exportOptions.plist'),

--- a/rnv-cli/src/platformTools/apple.js
+++ b/rnv-cli/src/platformTools/apple.js
@@ -368,13 +368,7 @@ const _postConfigureProject = (c, platform, appFolder, appFolderName, isBundled 
                     const plugin = plugins[key][platform];
                     if (plugin) {
                         if (plugins[key]['no-active'] !== true) {
-                            if (plugin.packages) {
-                                plugin.packages.forEach((ppkg) => {
-                                    _injectPlugin(c, plugin, key, ppkg, pluginConfig);
-                                });
-                            } else {
-                                _injectPlugin(c, plugin, key, plugin.package, pluginConfig);
-                            }
+                            _injectPlugin(c, plugin, key, plugin.package, pluginConfig);
                         }
                     }
                 }

--- a/rnv-cli/src/platformTools/apple.js
+++ b/rnv-cli/src/platformTools/apple.js
@@ -387,7 +387,7 @@ const _postConfigureProject = (c, platform, appFolder, appFolderName, isBundled 
             { pattern: '{{IP}}', override: ip },
             { pattern: '{{PORT}}', override: port },
             { pattern: '{{APPDELEGATE_IMPORTS}}', override: pluginConfig.pluginAppDelegateImports },
-            { pattern: '{{APPDELEGATE_METHODS}}', override: pluginConfig.pluginAppDelegateMethods },
+            { pattern: '{{APPDELEGATE_METHODS}}', override: 'IM A METHOD' },
         ]);
 
     writeCleanFile(path.join(appTemplateFolder, 'exportOptions.plist'),

--- a/rnv-cli/src/platformTools/apple.js
+++ b/rnv-cli/src/platformTools/apple.js
@@ -355,7 +355,6 @@ const _postConfigureProject = (c, platform, appFolder, appFolderName, isBundled 
     const pluginAppDelegateImports = '';
     const pluginAppDelegateMethods = '';
     const pluginConfig = {
-        pluginIncludes, pluginPaths, pluginImports, pluginPackages, pluginImplementations, pluginAfterEvaluate,
         pluginAppDelegateImports, pluginAppDelegateMethods,
     };
     // PLUGINS

--- a/rnv-cli/src/platformTools/apple.js
+++ b/rnv-cli/src/platformTools/apple.js
@@ -325,6 +325,7 @@ const configureXcodeProject = (c, platform, ip, port) => new Promise((resolve, r
 });
 
 const _injectPlugin = (c, plugin, key, pkg, pluginConfig) => {
+    logTask(`injecting plugin ${key}`);
     if (plugin.appDelegateImports instanceof Array) {
         plugin.appDelegateImports.forEach((appDelegateImport) => {
             // Avoid duplicate imports
@@ -377,6 +378,9 @@ const _postConfigureProject = (c, platform, appFolder, appFolderName, isBundled 
             }
         }
     }
+
+    logTask(`pluginConfig.pluginAppDelegateImports ${pluginConfig.pluginAppDelegateImports}`);
+    logTask(`pluginConfig.pluginAppDelegateImports ${pluginConfig.pluginAppDelegateMethods}`);
 
     writeCleanFile(path.join(getAppTemplateFolder(c, platform), appFolderName, appDelegate),
         path.join(appFolder, appFolderName, appDelegate),

--- a/rnv-cli/src/platformTools/apple.js
+++ b/rnv-cli/src/platformTools/apple.js
@@ -328,12 +328,16 @@ const _injectPlugin = (c, plugin, key, pkg, pluginConfig) => {
     if (plugin.appDelegateImports instanceof Array) {
         plugin.appDelegateImports.forEach((appDelegateImport) => {
             // Avoid duplicate imports
+            logTask('appDelegateImports add')
             if (pluginConfig.pluginAppDelegateImports.indexOf(appDelegateImport) === -1) {
+                logTask('appDelegateImports add ok')
                 pluginConfig.pluginAppDelegateImports += `import ${appDelegateImport}\n`;
             }
         });
     }
+    logTask('appDelegateMethods add')
     if (plugin.appDelegateMethods instanceof Array) {
+        logTask('appDelegateMethods add ok')
         pluginConfig.pluginAppDelegateMethods += `${plugin.appDelegateMethods.join('\n    ')}`;
     }
 }

--- a/rnv-cli/src/platformTools/apple.js
+++ b/rnv-cli/src/platformTools/apple.js
@@ -339,7 +339,7 @@ const _injectPlugin = (c, plugin, key, pkg, pluginConfig) => {
 }
 
 const _postConfigureProject = (c, platform, appFolder, appFolderName, isBundled = false, ip = 'localhost', port = 8081) => new Promise((resolve, reject) => {
-    logTask(`_postConfigureProject:${platform}:${ip}:${port}`);
+    logTask(`!_postConfigureProject:${platform}:${ip}:${port}`);
     const appDelegate = 'AppDelegate.swift';
 
     const entryFile = getEntryFile(c, platform);


### PR DESCRIPTION
Allow to introduce imports on:
- MainActivity via `activityImports`
- AppDelegate via `appDelegateImports`

Allow to introduce functions on:
- MainActivity via `activityMethods`
- AppDelegate via `appDelegateMethods`

This allowed me to setup `react-native-orientation-locker` correctly. And will allow other libraries that need imports / setup.