### PR TITLE
Fix webos build command

### DIFF
--- a/packages/rnv/src/platformTools/webos.js
+++ b/packages/rnv/src/platformTools/webos.js
@@ -236,7 +236,7 @@ const runWebOS = async (c, platform, target) => {
 const buildWebOSProject = (c, platform) => new Promise((resolve, reject) => {
     logTask(`buildWebOSProject:${platform}`);
 
-    const tDir = path.join(getAppFolder(c, platform), 'public');
+    const tDir = path.join(getAppFolder(c, platform), 'RNVApp');
     const tOut = path.join(getAppFolder(c, platform), 'output');
 
     configureWebOSProject(c, platform)


### PR DESCRIPTION
Unify the folder names for webos `run` and `build` command, fixing 
_rnv build -p webos - ERRROR! Command webosAresPackage failed_