### PR TITLE
Add custom values to andoird buildTypes

### DIFF
--- a/packages/rnv/src/platformTools/android/gradleParser.js
+++ b/packages/rnv/src/platformTools/android/gradleParser.js
@@ -106,8 +106,9 @@ keyPassword=${c.files.privateConfig[platform].keyPassword}`);
     }
 
     // BUILD_TYPES
-    const debugBuildTypes = c.files.pluginConfig?.android?.gradle?.buildTypes?.debug ?? [];
-    const releaseBuildTypes = c.files.pluginConfig?.android?.gradle?.buildTypes?.release ?? [];
+    const pluginConfig = c.files.pluginConfig ?? {};
+    const debugBuildTypes = pluginConfig[platform]?.gradle?.buildTypes?.debug ?? [];
+    const releaseBuildTypes = pluginConfig[platform]?.gradle?.buildTypes?.release ?? [];
     c.pluginConfigAndroid.buildTypes = `
     debug {
         minifyEnabled false

--- a/packages/rnv/src/platformTools/android/gradleParser.js
+++ b/packages/rnv/src/platformTools/android/gradleParser.js
@@ -106,15 +106,19 @@ keyPassword=${c.files.privateConfig[platform].keyPassword}`);
     }
 
     // BUILD_TYPES
+    const debugBuildTypes = c.files.pluginConfig?.android?.gradle?.buildTypes?.debug ?? [];
+    const releaseBuildTypes = c.files.pluginConfig?.android?.gradle?.buildTypes?.release ?? [];
     c.pluginConfigAndroid.buildTypes = `
     debug {
         minifyEnabled false
         proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        ${debugBuildTypes.join('\n        ')}
     }
     release {
         minifyEnabled false
         proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         signingConfig signingConfigs.release
+        ${releaseBuildTypes.join('\n        ')}
     }`;
 
 


### PR DESCRIPTION
For our project we need to set some custom BuildConfig variables, this works with setting buildConfigField inside build.gradle android.buildTypes.debug/release.

However, even when ejecting it was not possible to add fields to the build configs, since they are hardcoded.

I'm closing my issue #171 regarding this.