### PR TITLE
Added posibility to overwrite android getJsBundleFile via appConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,7 @@ For appConfigs:
 ```json
 {
   "entryFile": "",
+  "getJsBundleFile": "",
   "universalApk": true,
   "multipleAPKs": false,
   "minSdkVersion": 21,

--- a/packages/renative/README.md
+++ b/packages/renative/README.md
@@ -554,6 +554,7 @@ For appConfigs:
 ```json
 {
   "entryFile": "",
+  "getJsBundleFile": "",
   "universalApk": true,
   "multipleAPKs": false,
   "minSdkVersion": 21,

--- a/packages/rnv/platformTemplates/android/app/src/main/java/rnv/MainApplication.kt
+++ b/packages/rnv/platformTemplates/android/app/src/main/java/rnv/MainApplication.kt
@@ -29,6 +29,8 @@ class MainApplication : Application(), ReactApplication {
         }
 
         override fun getJSMainModuleName(): String = "{{ENTRY_FILE}}"
+
+        override fun getJSBundleFile(): String? = {{GET_JS_BUNDLE_FILE}}
     }
 
 {{PLUGIN_METHODS}}

--- a/packages/rnv/platformTemplates/androidtv/app/src/main/java/rnv/MainApplication.kt
+++ b/packages/rnv/platformTemplates/androidtv/app/src/main/java/rnv/MainApplication.kt
@@ -29,6 +29,8 @@ class MainApplication : Application(), ReactApplication {
         }
 
         override fun getJSMainModuleName(): String = "{{ENTRY_FILE}}"
+
+        override fun getJSBundleFile(): String? = {{GET_JS_BUNDLE_FILE}}
     }
 
 {{PLUGIN_METHODS}}

--- a/packages/rnv/platformTemplates/androidwear/app/src/main/java/rnv/MainApplication.kt
+++ b/packages/rnv/platformTemplates/androidwear/app/src/main/java/rnv/MainApplication.kt
@@ -29,8 +29,8 @@ class MainApplication : Application(), ReactApplication {
 
         override fun getJSMainModuleName(): String = "{{ENTRY_FILE}}"
 
-        //CRAPPY BUT Android Wear does not support webview required for connecting to packager
-        override fun getJSBundleFile(): String = "assets://{{ENTRY_FILE}}.bundle"
+        //See src/common.js for the actual code
+        override fun getJSBundleFile(): String? = {{GET_JS_BUNDLE_FILE}}
     }
 
     override fun getReactNativeHost(): ReactNativeHost = mReactNativeHost

--- a/packages/rnv/src/common.js
+++ b/packages/rnv/src/common.js
@@ -979,6 +979,13 @@ const getConfigProp = (c, platform, key, defaultVal) => {
     return result;
 };
 
+const getJsBundleFileDefaults = {
+    android: 'super.getJSBundleFile()',
+    androidtv: 'super.getJSBundleFile()',
+    //CRAPPY BUT Android Wear does not support webview required for connecting to packager
+    androidwear: '"assets://index.androidwear.bundle"',
+};
+
 const getAppId = (c, platform) => getConfigProp(c, platform, 'id');
 
 const getAppTitle = (c, platform) => getConfigProp(c, platform, 'title');
@@ -990,6 +997,8 @@ const getAppAuthor = (c, platform) => c.files.appConfigFile.platforms[platform].
 const getAppLicense = (c, platform) => c.files.appConfigFile.platforms[platform].license || c.files.appConfigFile.common.license || c.files.projectPackage.license;
 
 const getEntryFile = (c, platform) => c.files.appConfigFile.platforms[platform].entryFile;
+
+const getGetJsBundleFile = (c, platform) => c.files.appConfigFile.platforms[platform].getJsBundleFile || getJsBundleFileDefaults[platform];
 
 const getAppDescription = (c, platform) => c.files.appConfigFile.platforms[platform].description || c.files.appConfigFile.common.description || c.files.projectPackage.description;
 
@@ -1312,6 +1321,7 @@ export {
     writeCleanFile,
     copyBuildsFolder,
     getEntryFile,
+    getGetJsBundleFile,
     getAppConfigId,
     getAppDescription,
     getAppAuthor,
@@ -1388,6 +1398,7 @@ export default {
     getAppVersionCode,
     writeCleanFile,
     getEntryFile,
+    getGetJsBundleFile,
     getAppConfigId,
     getAppDescription,
     getAppAuthor,

--- a/packages/rnv/src/platformTools/android/kotlinParser.js
+++ b/packages/rnv/src/platformTools/android/kotlinParser.js
@@ -20,6 +20,7 @@ import {
     getAppTemplateFolder,
     getBuildFilePath,
     getEntryFile,
+    getGetJsBundleFile,
     logWarning,
     logDebug,
     getConfigProp,
@@ -36,6 +37,7 @@ export const parseMainApplicationSync = (c, platform) => {
     writeCleanFile(getBuildFilePath(c, platform, applicationPath), path.join(appFolder, applicationPath), [
         { pattern: '{{APPLICATION_ID}}', override: getAppId(c, platform) },
         { pattern: '{{ENTRY_FILE}}', override: getEntryFile(c, platform) },
+        { pattern: '{{GET_JS_BUNDLE_FILE}}', override: getGetJsBundleFile(c, platform) },
         { pattern: '{{PLUGIN_IMPORTS}}', override: c.pluginConfigAndroid.pluginImports },
         { pattern: '{{PLUGIN_PACKAGES}}', override: c.pluginConfigAndroid.pluginPackages },
         { pattern: '{{PLUGIN_METHODS}}', override: c.pluginConfigAndroid.mainApplicationMethods },


### PR DESCRIPTION
For our project we need to overwrite the method `getJsBundleFile` in `MainApplication.kt`. Since I don't like ejecting the app, I added this way to configure it via `appConfigs/xxx/config.json`.

To make it compatible to older renative projects which would need to modify their `config.json`, I added the default values to `src/common.js`.