### PR TITLE
Added params to Api.navigation.navigate

### DIFF
--- a/packages/renative/src/Api/index.js
+++ b/packages/renative/src/Api/index.js
@@ -10,9 +10,9 @@ export default {
             const nav = getNavigation();
             nav.dispatch(DrawerActions.openDrawer());
         },
-        navigate: (route) => {
+        navigate: (route, params = undefined) => {
             const nav = getNavigation();
-            nav.navigate(route);
+            nav.navigate(route, params);
         },
         pop: () => {
             const nav = getNavigation();


### PR DESCRIPTION
As far as I see renative currently only depends on `react-navigation`, so the API is easy to wrap.

Currently there are two ways to call the `navigate` function, described here: https://reactnavigation.org/docs/en/navigation-prop.html

I suggest for now we skip the `action` and `key` parameters to make it more compatible with other navigation libraries aside from `react-navigation` (if this ever will be a requirement for renative someday).

Closes issue #177.