### PR TITLE
Passing props to Navigator instance

### DIFF
--- a/packages/renative/src/Navigation/index.js
+++ b/packages/renative/src/Navigation/index.js
@@ -130,22 +130,19 @@ const createApp = (c, componentMap, navigatorProps = {}) => {
             }
         });
     } else {
-        rootWrapper = createSwitchNavigator(roots);
         const screensArr = [];
         for (const rk in root.screens) {
             screensArr.push(componentMap[root.screens[rk].screen]);
         }
         return (
-            <View style={{ flex: 1, backgroundColor: '#222222' }}>
-                <ScrollView>
-                    {
-                        screensArr.map((v) => {
-                            const Screen = v;
-                            return <Screen />;
-                        })
-                    }
-                </ScrollView>
-            </View>
+            <ScrollView style={{ flex: 1 }}>
+                {
+                    screensArr.map((v) => {
+                        const Screen = v;
+                        return <Screen />;
+                    })
+                }
+            </ScrollView>
         );
     }
 
@@ -153,16 +150,14 @@ const createApp = (c, componentMap, navigatorProps = {}) => {
     const Navigator = createAppContainer(rootWrapper);
 
     return (
-        <View style={{ flex: 1, flexDirection: 'row', backgroundColor: '#222222' }}>
-            <Navigator
-                ref={(nav) => {
-                    _currentNavigation = nav._navigation;
-                }}
-                onNavigationStateChange={handleNavigationChange}
-                uriPrefix="/app"
-                {...navigatorProps}
-            />
-        </View>
+        <Navigator
+            ref={(nav) => {
+                _currentNavigation = nav._navigation;
+            }}
+            onNavigationStateChange={handleNavigationChange}
+            uriPrefix="/app"
+            {...navigatorProps}
+        />
     );
 };
 

--- a/packages/renative/src/Navigation/index.js
+++ b/packages/renative/src/Navigation/index.js
@@ -44,7 +44,7 @@ const createFilteredStackNavigator = (c, componentMap, rootRoute, rootScreen, ro
     return createStackNavigator(stacks);
 };
 
-const createApp = (c, componentMap) => {
+const createApp = (c, componentMap, navigatorProps = {}) => {
     const root = c.root;
     let rootNav;
     let stackNav;
@@ -160,6 +160,7 @@ const createApp = (c, componentMap) => {
                 }}
                 onNavigationStateChange={handleNavigationChange}
                 uriPrefix="/app"
+                {...navigatorProps}
             />
         </View>
     );


### PR DESCRIPTION
This change allows to pass properties to navigator which is useable for eg. i18n.
See also https://reactnavigation.org/docs/en/localization.html

Aside from this I suggest to remove the hardcoded `backgroundColor` props from the `View` elements.