### PR TITLE
Feat/#180 android aab

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,7 @@ For appConfigs:
   "getJsBundleFile": "",
   "universalApk": true,
   "multipleAPKs": false,
+  "aab": false,
   "minSdkVersion": 21,
   "backgroundColor": "",
   "id": "",


### PR DESCRIPTION
specifying `aab: true` in `buildSchemes` does the job.

```
"buildSchemes": {
        "debug": {
          "id": "renative.helloworld.debug",
          "signingConfig": "Debug",
          "bundleAssets": true,
          "aab": true
        }
      }
```