### PR TITLE
Setting own bundle file on iOS

### DIFF
--- a/packages/rnv/src/common.js
+++ b/packages/rnv/src/common.js
@@ -225,7 +225,10 @@ export const getAppSubFolder = (c, platform) => {
     return path.join(getAppFolder(c, platform), subFolder);
 };
 
-export const getAppTemplateFolder = (c, platform) => path.join(c.paths.project.platformTemplatesDirs[platform], `${platform}`);
+export const getAppTemplateFolder = (c, platform) => {
+    console.warn('!!!!!!!!', c.paths.project.platformTemplatesDirs);
+    path.join(c.paths.project.platformTemplatesDirs[platform], `${platform}`)
+};
 
 export const getAppConfigId = (c, platform) => c.buildConfig.id;
 
@@ -280,13 +283,6 @@ export const getConfigProp = (c, platform, key, defaultVal) => {
     return result;
 };
 
-export const getJsBundleFileDefaults = {
-    android: 'super.getJSBundleFile()',
-    androidtv: 'super.getJSBundleFile()',
-    // CRAPPY BUT Android Wear does not support webview required for connecting to packager
-    androidwear: '"assets://index.androidwear.bundle"',
-};
-
 export const getAppId = (c, platform) => {
     const id = getConfigProp(c, platform, 'id');
     const idSuffix = getConfigProp(c, platform, 'idSuffix');
@@ -303,7 +299,7 @@ export const getAppLicense = (c, platform) => c.buildConfig.platforms[platform].
 
 export const getEntryFile = (c, platform) => c.buildConfig.platforms[platform].entryFile;
 
-export const getGetJsBundleFile = (c, platform) => c.buildConfig.platforms[platform].getJsBundleFile || getJsBundleFileDefaults[platform];
+export const getGetJsBundleFile = (c, platform) => getConfigProp(c, platform, 'getJsBundleFile');
 
 export const getAppDescription = (c, platform) => c.buildConfig.platforms[platform].description || c.buildConfig.common.description || c.files.project.package.description;
 

--- a/packages/rnv/src/platformTools/apple/swiftParser.js
+++ b/packages/rnv/src/platformTools/apple/swiftParser.js
@@ -34,8 +34,11 @@ export const parseAppDelegate = (c, platform, appFolder, appFolderName, isBundle
     const runScheme = getConfigProp(c, platform, 'runScheme');
     const allowProvisioningUpdates = getConfigProp(c, platform, 'allowProvisioningUpdates', true);
     const provisioningStyle = getConfigProp(c, platform, 'provisioningStyle', 'Automatic');
+    const forceBundle = getGetJsBundleFile(c, platform);
     let bundle;
-    if (isBundled) {
+    if (forceBundle) {
+        bundle = forceBundle;
+    } else if (isBundled) {
         bundle = `RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "${entryFile}", fallbackResource: nil)`;
     } else {
         bundle = `URL(string: "http://${ip}:${port}/${entryFile}.bundle?platform=ios")`;


### PR DESCRIPTION
Allows setting a custom bundle URL in native code, basically same as pr #174 but for iOS (and also tvOS?!)