### PR TITLE
Avoids the need to include children: [] when overriding AndroidManifest on renative.json files

### DIFF
--- a/packages/rnv/src/platformTools/android/manifestParser.js
+++ b/packages/rnv/src/platformTools/android/manifestParser.js
@@ -112,7 +112,7 @@ const _mergeNodeParameters = (node, nodeParamsExt) => {
 const PROHIBITED_DUPLICATE_TAGS = ['intent-filter'];
 const SYSTEM_TAGS = ['tag', 'children'];
 
-const _mergeNodeChildren = (node, nodeChildrenExt) => {
+const _mergeNodeChildren = (node, nodeChildrenExt = []) => {
     // console.log('_mergeNodeChildren', node, 'OVERRIDE', nodeChildrenExt);
     if (!node) {
         logWarning('_mergeNodeChildren: Node is undefined');


### PR DESCRIPTION
Closes https://github.com/pavjacko/renative/issues/278