### PR TITLE
Fix for web based tv extensions

### DIFF
--- a/packages/rnv/src/constants.js
+++ b/packages/rnv/src/constants.js
@@ -153,7 +153,7 @@ export const PLATFORMS = {
         isActive: true,
         requiresSharedConfig: true,
         sourceExts: {
-            factors: ['tizen.tv.js', 'tv.js'],
+            factors: ['tizen.tv.js', 'web.tv.js', 'tv.js'],
             platforms: ['tizen.js'],
             fallbacks: ['tv.web.js', 'web.js', 'js', 'tsx', 'ts']
         }
@@ -165,7 +165,7 @@ export const PLATFORMS = {
         isActive: true,
         requiresSharedConfig: true,
         sourceExts: {
-            factors: ['webos.tv.js', 'tv.js'],
+            factors: ['webos.tv.js', 'web.tv.js', 'tv.js'],
             platforms: ['webos.js'],
             fallbacks: ['tv.web.js', 'web.js', 'js', 'tsx', 'ts']
         }
@@ -249,7 +249,7 @@ export const PLATFORMS = {
         isActive: true,
         requiresSharedConfig: true,
         sourceExts: {
-            factors: ['firefoxtv.tv.js', 'tv.js'],
+            factors: ['firefoxtv.tv.js', 'web.tv.js', 'tv.js'],
             platforms: ['firefoxtv.js'],
             fallbacks: ['tv.web.js', 'web.js', 'js', 'tsx', 'ts']
         }


### PR DESCRIPTION
I need a way to address all web-based tv platforms in case there is already existing `.tv.js` that is intended  for native TVs (tvOS, AndroidTV)

At the current state, I'm unable to do so. Fallback `tv.web.js` has a lower priority than `tv.js`

Before this PR the priorities for tizen platform are:
```
[
  '.tizen.tv.js',
  '.tv.js',
  '.tizen.js',
  '.tv.web.js',
  '.web.js',
  '.js',
  '.tsx',
  '.ts'
]
```

I need an option between `tizen.tv.js` and `tv.js`