### PR TITLE
don't tell users to run on web if web is not selected

### DIFF
--- a/packages/rnv/src/projectTools/projectGenerator.js
+++ b/packages/rnv/src/projectTools/projectGenerator.js
@@ -204,7 +204,7 @@ const _generateProject = (c, data) => {
 
         logSuccess(
             `Your project is ready! navigate to project ${chalk.white(`cd ${data.projectName}`)} and run ${chalk.white(
-                'rnv run -p web',
+                `rnv run -p ${data.optionPlatforms.selectedOptions[0]}`,
             )} to see magic happen!`,
         );
     });


### PR DESCRIPTION
when creating a new project rnv would tell users to run `rnv run -p web` even if web was not selected. Changed it to the first platform from array