### PR TITLE
Added nullish-coalescing-operator babel plugin

### DIFF
--- a/packages/rnv-deploy-docker/.babelrc
+++ b/packages/rnv-deploy-docker/.babelrc
@@ -1,6 +1,7 @@
 {
   "plugins": [
-    "@babel/plugin-proposal-optional-chaining"
+    "@babel/plugin-proposal-optional-chaining",
+    "@babel/plugin-proposal-nullish-coalescing-operator"
   ],
   "presets": [
     [

--- a/packages/rnv-deploy-docker/package.json
+++ b/packages/rnv-deploy-docker/package.json
@@ -30,8 +30,9 @@
         "@babel/cli": "7.6.0",
         "@babel/core": "7.6.0",
         "@babel/node": "7.6.1",
-        "@babel/preset-env": "7.6.0",
-        "@babel/plugin-proposal-optional-chaining": "7.6.0"
+        "@babel/plugin-proposal-nullish-coalescing-operator": "7.7.4",
+        "@babel/plugin-proposal-optional-chaining": "7.6.0",
+        "@babel/preset-env": "7.6.0"
     },
     "dependencies": {
         "get-installed-path": "^4.0.8"

--- a/packages/rnv/package.json
+++ b/packages/rnv/package.json
@@ -78,6 +78,7 @@
         "@babel/core": "7.1.2",
         "@babel/plugin-proposal-class-properties": "7.4.4",
         "@babel/plugin-proposal-decorators": "7.1.2",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "7.7.4",
         "@babel/plugin-proposal-optional-chaining": "7.6.0",
         "@babel/plugin-transform-runtime": "7.1.0",
         "@babel/preset-env": "7.3.4",

--- a/packages/rnv/src/projectTools/buildHooks.js
+++ b/packages/rnv/src/projectTools/buildHooks.js
@@ -73,7 +73,7 @@ const buildHooks = c => new Promise((resolve, reject) => {
             return;
         }
 
-        executeAsync(c, `babel --no-babelrc --plugins @babel/plugin-proposal-optional-chaining ${c.paths.buildHooks.dir} -d ${c.paths.buildHooks.dist.dir} --presets=@babel/env`, {
+        executeAsync(c, `babel --no-babelrc --plugins @babel/plugin-proposal-optional-chaining,@babel/plugin-proposal-nullish-coalescing-operator ${c.paths.buildHooks.dir} -d ${c.paths.buildHooks.dist.dir} --presets=@babel/env`, {
             cwd: c.paths.buildHooks.dir
         })
             .then(() => {


### PR DESCRIPTION
Added the `nullish-coalescing-operator` babel plugin so that it can be used in combination with the `optional-chaining` babel plugin (which was already part of rnv).

E.g.;

```javascript
let customer = {
  name: "Carl",
  details: { age: 82 }
};
let customerCity = customer?.city ?? "Unknown city";
```

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining#Combining_with_the_nullish_coalescing_operator