### PR TITLE
Use Lerna For Monorepo Clean

### DIFF
--- a/packages/rnv/package.json
+++ b/packages/rnv/package.json
@@ -186,5 +186,8 @@
         "collectCoverage": true
     },
     "title": "ReNative CLI",
-    "codename": "Iron Ladybird"
+    "codename": "Iron Ladybird",
+    "workspaces": {
+        "nohoist": ["execa"]
+    }
 }

--- a/packages/rnv/src/systemTools/cleaner.js
+++ b/packages/rnv/src/systemTools/cleaner.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import path from 'path';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 import {isMonorepo, getMonorepoRoot} from '../common'
@@ -25,40 +24,15 @@ const doCleanMonorepo = async (c, skipQuestion) => {
         'lerna exec -- rm yarn.lock package-lock.json .DS_Store || true',
         { cwd: getMonorepoRoot(), shell: true }
     );
+    await executeAsync(
+        c,
+        'rm -rf node_modules package-lock.json yarn.lock .DS_Store || true',
+        { cwd: getMonorepoRoot(), shell: true }
+    );
 };
 const rnvClean = async (c, skipQuestion = false) => {
     logTask('rnvClean');
     if (c.program.ci) skipQuestion = true;
-
-    // const packagesFolder = path.join(c.paths.project.dir, 'packages');
-    // if (fs.existsSync(packagesFolder)) {
-    //     fs.readdirSync(packagesFolder).forEach((dir) => {
-    //         if (dir === '.DS_Store') {
-    //             const pth = path.join(packagesFolder, dir);
-
-    //             if (fs.existsSync(pth)) {
-    //                 pathsToRemove.push(pth);
-    //                 msg += chalk.red(`${pth}\n`);
-    //             }
-    //         } else {
-    //             const pth2 = path.join(packagesFolder, dir, 'node_modules');
-    //             if (fs.existsSync(pth2)) {
-    //                 pathsToRemove.push(pth2);
-    //                 msg += chalk.red(`${pth2}\n`);
-    //             }
-
-    //             const pth3 = path.join(
-    //                 packagesFolder,
-    //                 dir,
-    //                 'package-lock.json'
-    //             );
-    //             if (fs.existsSync(pth3)) {
-    //                 pathsToRemove.push(pth3);
-    //                 msg += chalk.red(`${pth3}\n`);
-    //             }
-    //         }
-    //     });
-    // }
 
     const buildDirs = [];
     if (fs.existsSync(c.paths.project.builds.dir)) { buildDirs.push(c.paths.project.builds.dir); }
@@ -71,19 +45,6 @@ const rnvClean = async (c, skipQuestion = false) => {
         nothingToClean: !skipQuestion
     };
 
-    // if (pathsToRemove.length) {
-    //     if (!skipQuestion) {
-    //         const { confirm } = await inquirer.prompt({
-    //             name: 'confirm',
-    //             type: 'confirm',
-    //             message: `Do you want to remove node_module related files/folders? \n${msg}`
-    //         });
-    //         answers.modules = confirm;
-    //         if (confirm) answers.nothingToClean = false;
-    //     } else {
-    //         answers.modules = true;
-    //     }
-    // }
     if (!skipQuestion) {
         const { confirm } = await inquirer.prompt({
             name: 'confirm',
@@ -95,7 +56,6 @@ const rnvClean = async (c, skipQuestion = false) => {
     } else {
         answers.modules = true;
     }
-
 
     if (buildDirs.length) {
         if (!skipQuestion) {
@@ -142,126 +102,12 @@ const rnvClean = async (c, skipQuestion = false) => {
         await removeDirs(buildDirs);
     }
     if (answers.cache) {
-        await executeAsync(c, 'watchman watch-del-all');
+        await executeAsync(c, 'npx watchman watch-del-all || true', { shell: true });
         await executeAsync(
             c,
             'rm -rf $TMPDIR/metro-* && rm -rf $TMPDIR/react-* && rm -rf $TMPDIR/haste-*'
         );
     }
 };
-// const rnvClean = async (c, skipQuestion = false) => {
-//     logTask('rnvClean');
-//     if (c.program.ci) skipQuestion = true;
-//     const pathsToRemove = [];
-//     const immediateNodeModuleDir = path.join(
-//         c.paths.project.dir,
-//         'node_modules'
-//     );
-//     const pkgLock = path.join(c.paths.project.dir, 'package-lock.json');
-//     if (fs.existsSync(immediateNodeModuleDir)) { pathsToRemove.push(immediateNodeModuleDir); }
-//     if (fs.existsSync(pkgLock)) pathsToRemove.push(pkgLock);
-//     let msg = chalk.red(`${pkgLock}\n${immediateNodeModuleDir}`);
-//     const packagesFolder = path.join(c.paths.project.dir, 'packages');
-//     if (fs.existsSync(packagesFolder)) {
-//         fs.readdirSync(packagesFolder).forEach((dir) => {
-//             if (dir === '.DS_Store') {
-//                 const pth = path.join(packagesFolder, dir);
-
-//                 if (fs.existsSync(pth)) {
-//                     pathsToRemove.push(pth);
-//                     msg += chalk.red(`${pth}\n`);
-//                 }
-//             } else {
-//                 const pth2 = path.join(packagesFolder, dir, 'node_modules');
-//                 if (fs.existsSync(pth2)) {
-//                     pathsToRemove.push(pth2);
-//                     msg += chalk.red(`${pth2}\n`);
-//                 }
-
-//                 const pth3 = path.join(
-//                     packagesFolder,
-//                     dir,
-//                     'package-lock.json'
-//                 );
-//                 if (fs.existsSync(pth3)) {
-//                     pathsToRemove.push(pth3);
-//                     msg += chalk.red(`${pth3}\n`);
-//                 }
-//             }
-//         });
-//     }
-
-//     const buildDirs = [];
-//     if (fs.existsSync(c.paths.project.builds.dir)) { buildDirs.push(c.paths.project.builds.dir); }
-//     if (fs.existsSync(c.paths.project.assets.dir)) { buildDirs.push(c.paths.project.assets.dir); }
-
-//     const answers = {
-//         modules: false,
-//         builds: false,
-//         cache: false,
-//         nothingToClean: !skipQuestion
-//     };
-
-//     if (pathsToRemove.length) {
-//         if (!skipQuestion) {
-//             const { confirm } = await inquirer.prompt({
-//                 name: 'confirm',
-//                 type: 'confirm',
-//                 message: `Do you want to remove node_module related files/folders? \n${msg}`
-//             });
-//             answers.modules = confirm;
-//             if (confirm) answers.nothingToClean = false;
-//         } else {
-//             answers.modules = true;
-//         }
-//     }
-
-//     if (buildDirs.length) {
-//         if (!skipQuestion) {
-//             const { confirmBuilds } = await inquirer.prompt({
-//                 name: 'confirmBuilds',
-//                 type: 'confirm',
-//                 message: `Do you want to clean your platformBuilds and platformAssets? \n${chalk.red(
-//                     buildDirs.join('\n')
-//                 )}`
-//             });
-//             answers.builds = confirmBuilds;
-//             if (confirmBuilds) answers.nothingToClean = false;
-//         } else {
-//             answers.builds = true;
-//         }
-//     }
-
-//     if (!skipQuestion) {
-//         const { confirmCache } = await inquirer.prompt({
-//             name: 'confirmCache',
-//             type: 'confirm',
-//             message: 'Do you want to clean your npm/bundler cache?'
-//         });
-//         answers.cache = confirmCache;
-//         if (confirmCache) answers.nothingToClean = false;
-//     } else {
-//         answers.cache = true;
-//     }
-
-//     if (answers.nothingToClean) {
-//         logToSummary('Nothing to clean');
-//         return Promise.resolve();
-//     }
-
-//     if (answers.modules) {
-//         await removeDirs(pathsToRemove);
-//     }
-//     if (answers.builds) {
-//         await removeDirs(buildDirs);
-//     }
-//     if (answers.cache) {
-//         await executeAsync(c, 'watchman watch-del-all');
-//         await executeAsync(
-//             c,
-//             'rm -rf $TMPDIR/metro-* && rm -rf $TMPDIR/react-* && rm -rf $TMPDIR/haste-*'
-//         );
-//     }
-// };
 
 export { rnvClean };

--- a/packages/rnv/src/systemTools/cleaner.js
+++ b/packages/rnv/src/systemTools/cleaner.js
@@ -2,52 +2,63 @@ import fs from 'fs';
 import path from 'path';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
-
+import {isMonorepo, getMonorepoRoot} from '../common'
 import { removeDirs } from './fileutils';
 import { logTask, logToSummary } from './logger';
 import { executeAsync } from './exec';
 
+const doCleanPackage = async (c, skipQuestion) => {
+    await executeAsync(
+        c,
+        'rm -rf node_modules package-lock.json yarn.lock .DS_Store || true',
+        { shell: true }
+    );
+};
+const doCleanMonorepo = async (c, skipQuestion) => {
+    await executeAsync(
+        c,
+        'npx lerna clean --yes',
+        { cwd: getMonorepoRoot(), shell: true }
+    );
+    await executeAsync(
+        c,
+        'lerna exec -- rm yarn.lock package-lock.json .DS_Store || true',
+        { cwd: getMonorepoRoot(), shell: true }
+    );
+};
 const rnvClean = async (c, skipQuestion = false) => {
     logTask('rnvClean');
     if (c.program.ci) skipQuestion = true;
-    const pathsToRemove = [];
-    const immediateNodeModuleDir = path.join(
-        c.paths.project.dir,
-        'node_modules'
-    );
-    const pkgLock = path.join(c.paths.project.dir, 'package-lock.json');
-    if (fs.existsSync(immediateNodeModuleDir)) { pathsToRemove.push(immediateNodeModuleDir); }
-    if (fs.existsSync(pkgLock)) pathsToRemove.push(pkgLock);
-    let msg = chalk.red(`${pkgLock}\n${immediateNodeModuleDir}`);
-    const packagesFolder = path.join(c.paths.project.dir, 'packages');
-    if (fs.existsSync(packagesFolder)) {
-        fs.readdirSync(packagesFolder).forEach((dir) => {
-            if (dir === '.DS_Store') {
-                const pth = path.join(packagesFolder, dir);
 
-                if (fs.existsSync(pth)) {
-                    pathsToRemove.push(pth);
-                    msg += chalk.red(`${pth}\n`);
-                }
-            } else {
-                const pth2 = path.join(packagesFolder, dir, 'node_modules');
-                if (fs.existsSync(pth2)) {
-                    pathsToRemove.push(pth2);
-                    msg += chalk.red(`${pth2}\n`);
-                }
+    // const packagesFolder = path.join(c.paths.project.dir, 'packages');
+    // if (fs.existsSync(packagesFolder)) {
+    //     fs.readdirSync(packagesFolder).forEach((dir) => {
+    //         if (dir === '.DS_Store') {
+    //             const pth = path.join(packagesFolder, dir);
 
-                const pth3 = path.join(
-                    packagesFolder,
-                    dir,
-                    'package-lock.json'
-                );
-                if (fs.existsSync(pth3)) {
-                    pathsToRemove.push(pth3);
-                    msg += chalk.red(`${pth3}\n`);
-                }
-            }
-        });
-    }
+    //             if (fs.existsSync(pth)) {
+    //                 pathsToRemove.push(pth);
+    //                 msg += chalk.red(`${pth}\n`);
+    //             }
+    //         } else {
+    //             const pth2 = path.join(packagesFolder, dir, 'node_modules');
+    //             if (fs.existsSync(pth2)) {
+    //                 pathsToRemove.push(pth2);
+    //                 msg += chalk.red(`${pth2}\n`);
+    //             }
+
+    //             const pth3 = path.join(
+    //                 packagesFolder,
+    //                 dir,
+    //                 'package-lock.json'
+    //             );
+    //             if (fs.existsSync(pth3)) {
+    //                 pathsToRemove.push(pth3);
+    //                 msg += chalk.red(`${pth3}\n`);
+    //             }
+    //         }
+    //     });
+    // }
 
     const buildDirs = [];
     if (fs.existsSync(c.paths.project.builds.dir)) { buildDirs.push(c.paths.project.builds.dir); }
@@ -60,19 +71,31 @@ const rnvClean = async (c, skipQuestion = false) => {
         nothingToClean: !skipQuestion
     };
 
-    if (pathsToRemove.length) {
-        if (!skipQuestion) {
-            const { confirm } = await inquirer.prompt({
-                name: 'confirm',
-                type: 'confirm',
-                message: `Do you want to remove node_module related files/folders? \n${msg}`
-            });
-            answers.modules = confirm;
-            if (confirm) answers.nothingToClean = false;
-        } else {
-            answers.modules = true;
-        }
+    // if (pathsToRemove.length) {
+    //     if (!skipQuestion) {
+    //         const { confirm } = await inquirer.prompt({
+    //             name: 'confirm',
+    //             type: 'confirm',
+    //             message: `Do you want to remove node_module related files/folders? \n${msg}`
+    //         });
+    //         answers.modules = confirm;
+    //         if (confirm) answers.nothingToClean = false;
+    //     } else {
+    //         answers.modules = true;
+    //     }
+    // }
+    if (!skipQuestion) {
+        const { confirm } = await inquirer.prompt({
+            name: 'confirm',
+            type: 'confirm',
+            message: `Do you want to remove node_module related files/folders?`
+        });
+        answers.modules = confirm;
+        if (confirm) answers.nothingToClean = false;
+    } else {
+        answers.modules = true;
     }
+
 
     if (buildDirs.length) {
         if (!skipQuestion) {
@@ -108,7 +131,12 @@ const rnvClean = async (c, skipQuestion = false) => {
     }
 
     if (answers.modules) {
-        await removeDirs(pathsToRemove);
+        if (isMonorepo()) {
+            await doCleanMonorepo(c, skipQuestion);
+        }
+        else {
+            doCleanPackage(c, skipQuestion);
+        }
     }
     if (answers.builds) {
         await removeDirs(buildDirs);
@@ -121,5 +149,119 @@ const rnvClean = async (c, skipQuestion = false) => {
         );
     }
 };
+// const rnvClean = async (c, skipQuestion = false) => {
+//     logTask('rnvClean');
+//     if (c.program.ci) skipQuestion = true;
+//     const pathsToRemove = [];
+//     const immediateNodeModuleDir = path.join(
+//         c.paths.project.dir,
+//         'node_modules'
+//     );
+//     const pkgLock = path.join(c.paths.project.dir, 'package-lock.json');
+//     if (fs.existsSync(immediateNodeModuleDir)) { pathsToRemove.push(immediateNodeModuleDir); }
+//     if (fs.existsSync(pkgLock)) pathsToRemove.push(pkgLock);
+//     let msg = chalk.red(`${pkgLock}\n${immediateNodeModuleDir}`);
+//     const packagesFolder = path.join(c.paths.project.dir, 'packages');
+//     if (fs.existsSync(packagesFolder)) {
+//         fs.readdirSync(packagesFolder).forEach((dir) => {
+//             if (dir === '.DS_Store') {
+//                 const pth = path.join(packagesFolder, dir);
+
+//                 if (fs.existsSync(pth)) {
+//                     pathsToRemove.push(pth);
+//                     msg += chalk.red(`${pth}\n`);
+//                 }
+//             } else {
+//                 const pth2 = path.join(packagesFolder, dir, 'node_modules');
+//                 if (fs.existsSync(pth2)) {
+//                     pathsToRemove.push(pth2);
+//                     msg += chalk.red(`${pth2}\n`);
+//                 }
+
+//                 const pth3 = path.join(
+//                     packagesFolder,
+//                     dir,
+//                     'package-lock.json'
+//                 );
+//                 if (fs.existsSync(pth3)) {
+//                     pathsToRemove.push(pth3);
+//                     msg += chalk.red(`${pth3}\n`);
+//                 }
+//             }
+//         });
+//     }
+
+//     const buildDirs = [];
+//     if (fs.existsSync(c.paths.project.builds.dir)) { buildDirs.push(c.paths.project.builds.dir); }
+//     if (fs.existsSync(c.paths.project.assets.dir)) { buildDirs.push(c.paths.project.assets.dir); }
+
+//     const answers = {
+//         modules: false,
+//         builds: false,
+//         cache: false,
+//         nothingToClean: !skipQuestion
+//     };
+
+//     if (pathsToRemove.length) {
+//         if (!skipQuestion) {
+//             const { confirm } = await inquirer.prompt({
+//                 name: 'confirm',
+//                 type: 'confirm',
+//                 message: `Do you want to remove node_module related files/folders? \n${msg}`
+//             });
+//             answers.modules = confirm;
+//             if (confirm) answers.nothingToClean = false;
+//         } else {
+//             answers.modules = true;
+//         }
+//     }
+
+//     if (buildDirs.length) {
+//         if (!skipQuestion) {
+//             const { confirmBuilds } = await inquirer.prompt({
+//                 name: 'confirmBuilds',
+//                 type: 'confirm',
+//                 message: `Do you want to clean your platformBuilds and platformAssets? \n${chalk.red(
+//                     buildDirs.join('\n')
+//                 )}`
+//             });
+//             answers.builds = confirmBuilds;
+//             if (confirmBuilds) answers.nothingToClean = false;
+//         } else {
+//             answers.builds = true;
+//         }
+//     }
+
+//     if (!skipQuestion) {
+//         const { confirmCache } = await inquirer.prompt({
+//             name: 'confirmCache',
+//             type: 'confirm',
+//             message: 'Do you want to clean your npm/bundler cache?'
+//         });
+//         answers.cache = confirmCache;
+//         if (confirmCache) answers.nothingToClean = false;
+//     } else {
+//         answers.cache = true;
+//     }
+
+//     if (answers.nothingToClean) {
+//         logToSummary('Nothing to clean');
+//         return Promise.resolve();
+//     }
+
+//     if (answers.modules) {
+//         await removeDirs(pathsToRemove);
+//     }
+//     if (answers.builds) {
+//         await removeDirs(buildDirs);
+//     }
+//     if (answers.cache) {
+//         await executeAsync(c, 'watchman watch-del-all');
+//         await executeAsync(
+//             c,
+//             'rm -rf $TMPDIR/metro-* && rm -rf $TMPDIR/react-* && rm -rf $TMPDIR/haste-*'
+//         );
+//     }
+// };
 
 export { rnvClean };


### PR DESCRIPTION
We were imperatively deleting files across the monorepo so now leverage lerna as it has knowledge of our workspaces.

It's a bit more resilient now also in case files aren't there etc.

To test:
 - `yarn run link`
 - `cd package/app`
 - `rnv clean`