### PR TITLE
Adds watchFolders to metro.config for monorepos

### DIFF
--- a/packages/rnv/projectTemplate/metro.config.js
+++ b/packages/rnv/projectTemplate/metro.config.js
@@ -12,7 +12,8 @@ const config = {
             /metro.config.local.*/
         ])
     },
-    projectRoot: path.resolve(__dirname)
+    projectRoot: path.resolve(__dirname),
+    watchFolders: [{{METRO_WATCH_FOLDERS}}]
 };
 
 module.exports = config;

--- a/packages/rnv/src/configTools/configParser.js
+++ b/packages/rnv/src/configTools/configParser.js
@@ -30,9 +30,10 @@ import {
     getRealPath,
     sanitizeDynamicRefs,
     sanitizeDynamicProps,
-    mergeObjects
+    mergeObjects,
+    copyFileWithInjectSync
 } from '../systemTools/fileutils';
-import { getSourceExtsAsString, getConfigProp } from '../common';
+import { getSourceExtsAsString, getConfigProp, isMonorepo } from '../common';
 import { doResolve } from '../resolve';
 import { getWorkspaceDirPath } from '../projectTools/workspace';
 import {
@@ -213,9 +214,11 @@ export const fixRenativeConfigsSync = async (c) => {
                 c.paths.project.rnCliConfig
             )} is missing! Let's create one for you.`
         );
-        copyFileSync(
+        copyFileWithInjectSync(
             path.join(c.paths.rnv.projectTemplate.dir, RN_CLI_CONFIG_NAME),
-            c.paths.project.rnCliConfig
+            c.paths.project.rnCliConfig,
+            false,
+            [{ pattern: /{{METRO_WATCH_FOLDERS}}/, override: isMonorepo() ? `path.resolve(__dirname, 'node_modules'), path.resolve('../../node_modules')` : '' }]
         );
     }
 

--- a/packages/rnv/src/configTools/configParser.js
+++ b/packages/rnv/src/configTools/configParser.js
@@ -218,7 +218,7 @@ export const fixRenativeConfigsSync = async (c) => {
             path.join(c.paths.rnv.projectTemplate.dir, RN_CLI_CONFIG_NAME),
             c.paths.project.rnCliConfig,
             false,
-            [{ pattern: /{{METRO_WATCH_FOLDERS}}/, override: isMonorepo() ? `path.resolve(__dirname, 'node_modules'), path.resolve('../../node_modules')` : '' }]
+            [{ pattern: /{{METRO_WATCH_FOLDERS}}/, override: isMonorepo() ? `path.resolve(__dirname, 'node_modules'), path.resolve(__dirname, '../../node_modules')` : '' }]
         );
     }
 


### PR DESCRIPTION
As n_m folders are outside the metro root, metro cannot resolve hoisted deps. This fixes that (only affects monorepo projects)