### PR TITLE
[Bug] Copy File Bug

### DIFF
--- a/packages/rnv/src/systemTools/fileutils.js
+++ b/packages/rnv/src/systemTools/fileutils.js
@@ -30,7 +30,7 @@ export const copyFileSync = (source, target, skipOverride) => {
     }
     logDebug('copyFileSync', source, targetFile, 'executed');
     try {
-        fs.writeFileSync(targetFile, fs.readFileSync(source));
+        fs.copyFileSync(source, targetFile);
     } catch (e) {
         console.log('copyFileSync', e);
     }


### PR DESCRIPTION
In certain edge cases, have been seeing corrupted files (images, gradlew files). Tracked it down to a mismatched Buffer/Unicode read/write copy.