### PR TITLE
closes #490

### DIFF
--- a/packages/rnv/src/systemTools/fileutils.js
+++ b/packages/rnv/src/systemTools/fileutils.js
@@ -189,6 +189,15 @@ export const copyFolderContentsRecursiveSync = (source, target, convertSvg = tru
                     copyFolderRecursiveSync(curSource, targetFolder, convertSvg, skipOverride, injectObject);
                 } else if (injectObject !== null) {
                     copyFileWithInjectSync(curSource, targetFolder, skipOverride, injectObject);
+                } else if (path.extname(curSource) === '.svg' && convertSvg === true) {
+                    const jsDest = path.join(
+                        targetFolder,
+                        `${path.basename(curSource)}.js`
+                    );
+                    logDebug(
+                        `file ${curSource} is svg and convertSvg is set to true. converting to ${jsDest}`
+                    );
+                    saveAsJs(curSource, jsDest);
                 } else {
                     copyFileSync(curSource, targetFolder, skipOverride);
                 }


### PR DESCRIPTION
## Description 

Add svg handling in `copyFolderContentsRecursiveSync` as well

## Remarks

Make sure you delete `x.svg` file that was copied over previously, otherwise it will pick that up instead of `x.svg.js` 
    
 ## I have tested my changes on:
 
 ReNative project directly:
 
* [x] android simulator