### PR TITLE
[Tizen] Add app version to Tizen template

### DIFF
--- a/packages/rnv/platformTemplates/tizen/config.xml
+++ b/packages/rnv/platformTemplates/tizen/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<widget xmlns="http://www.w3.org/ns/widgets" xmlns:tizen="http://tizen.org/ns/widgets" id="http://pavjacko/ReactNativeVanilla" version="0.8.5" viewmodes="maximized">
+<widget xmlns="http://www.w3.org/ns/widgets" xmlns:tizen="http://tizen.org/ns/widgets" id="http://pavjacko/ReactNativeVanilla" version="{{APP_VERSION}}" viewmodes="maximized">
     <tizen:application id="{{ID}}" package="{{PACKAGE}}" required_version="2.3"/>
     <content src="public/index.html"/>
     <feature name="http://tizen.org/feature/screen.size.normal.1080.1920"/>

--- a/packages/rnv/src/platformTools/tizen/index.js
+++ b/packages/rnv/src/platformTools/tizen/index.js
@@ -509,7 +509,7 @@ export const configureProject = (c, platform) => new Promise((resolve) => {
             { pattern: '{{PACKAGE}}', override: p.package },
             { pattern: '{{ID}}', override: p.id },
             { pattern: '{{APP_NAME}}', override: p.appName },
-            { pattern: '{{APP_VERSION}}', override: semver.coerce(getAppVersion(c, platform))
+            { pattern: '{{APP_VERSION}}', override: semver.coerce(getAppVersion(c, platform)) }
         ]
     );
 

--- a/packages/rnv/src/platformTools/tizen/index.js
+++ b/packages/rnv/src/platformTools/tizen/index.js
@@ -2,6 +2,7 @@
 import path from 'path';
 import fs from 'fs';
 import chalk from 'chalk';
+import semver from 'semver';
 import inquirer from 'inquirer';
 import net from 'net';
 import parser from 'xml2json';
@@ -15,6 +16,7 @@ import {
 } from '../../constants';
 import {
     getAppFolder,
+    getAppVersion,
     writeCleanFile,
     getAppTemplateFolder,
     getConfigProp,
@@ -506,7 +508,8 @@ export const configureProject = (c, platform) => new Promise((resolve) => {
         [
             { pattern: '{{PACKAGE}}', override: p.package },
             { pattern: '{{ID}}', override: p.id },
-            { pattern: '{{APP_NAME}}', override: p.appName }
+            { pattern: '{{APP_NAME}}', override: p.appName },
+            { pattern: '{{APP_VERSION}}', override: semver.coerce(getAppVersion(c, platform))
         ]
     );
 


### PR DESCRIPTION
## Description 

Renative lacked version support for Tizen. The version was fixed at 0.8.5. This pull request adds this functionality.

## Breaking Changes

none
 
## Note

Maybe `ReactNativeVanilla` should be replaced as well.
