### PR TITLE
feat(platform-tizen): add custom security profile

### DIFF
--- a/packages/rnv/src/platformTools/tizen/index.js
+++ b/packages/rnv/src/platformTools/tizen/index.js
@@ -118,6 +118,7 @@ export const createDevelopTizenCertificate = c => new Promise((resolve, reject) 
         c,
         CLI_TIZEN,
         `certificate -- ${certDirPath} -a rnv -f ${certFilename} -p ${certPassword}`,
+        { privateParams: [certPassword] },
     )
         .then(() => addDevelopTizenCertificate(c, {
             profileName: DEFAULT_SECURITY_PROFILE_NAME,
@@ -139,6 +140,7 @@ export const addDevelopTizenCertificate = (c, secureProfileConfig) => new Promis
         c,
         CLI_TIZEN,
         `security-profiles add -n ${profileName} -a ${certPath} -p ${certPassword}`,
+        { privateParams: [certPassword] },
     )
         .then(() => resolve())
         .catch((e) => {


### PR DESCRIPTION
## Description 

- add possibility to add custom [Tizen security profiles](https://developer.tizen.org/ko/development/tizen-studio/web-tools/cli#Manage_sec_prof) (sign package with custom certificate)
- mask passwords when creating new Tizen certificate or Tizen security profile

## Breaking Changes

- none