### PR TITLE
Update gradle version

### DIFF
--- a/packages/rnv/src/engine-rn/platformTemplates/androidtv/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/rnv/src/engine-rn/platformTemplates/androidtv/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Aug 04 03:02:25 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/packages/rnv/src/engine-rn/platformTemplates/androidwear/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/rnv/src/engine-rn/platformTemplates/androidwear/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Feb 16 18:07:06 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
## Description 
Unify gradle version across all Android based platforms.
AndroidTV and Wear platform templates had older gradle version, what can cause issues, 
eg latest Firebase analytics is not able to compile with it because of `unknown function platform()` introduced in higher gradle versions

## Breaking Changes

No breaking changes
    
 ## I have tested my changes on:
 
 ReNative project directly:
 
* [ ] ios simulator
* [ ] ios device
* [x] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [x] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
