### PR TITLE
[fix] add support for complex package versions in getAppVersionCode

### DIFF
--- a/docs/api-config.md
+++ b/docs/api-config.md
@@ -354,10 +354,36 @@ Common properties inherited for every platform
         "backgroundColor": "",
         "port": 1111,
         "versionCodeOffset": 0,
+        "versionCodeFormat": "00.00.00",
         "runtime": {}
     }
 }
 ```
+
+### versionCodeFormat
+
+allows you to fine-tune auto generated version codes
+
+default value: `00.00.00`
+
+
+IN: 1.2.3-rc.4+build.56
+OUT: 102030456
+
+IN: 1.2.3
+OUT: 10203
+
+-------------
+
+"versionCodeFormat" : "00.00.00.00.00"
+
+IN: 1.2.3-rc.4+build.56
+OUT: 102030456
+
+IN: 1.2.3
+OUT: 102030000
+
+--------------
 
 ## platforms
 

--- a/packages/rnv/src/core/common.js
+++ b/packages/rnv/src/core/common.js
@@ -309,16 +309,29 @@ export const getAppVersionCode = (c, platform) => {
     const versionCode = getConfigProp(c, platform, 'versionCode');
     if (versionCode) return versionCode;
     const version = getAppVersion(c, platform);
-    const versionNumberMaxCount = getConfigProp(c, platform, 'versionCodeMaxCount', 3);
+    const versionCodeFormat = getConfigProp(c, platform, 'versionCodeFormat', '00.00.00');
+    const vFormatArr = versionCodeFormat.split('.').map(v => v.length);
+    const versionCodeMaxCount = vFormatArr.length;
+
     const verArr = [];
     version.split('.').map(v => v.split('-').map(v2 => v2.split('+').forEach((v3) => {
         const asNumber = Number(v3);
         if (!Number.isNaN(asNumber)) {
-            const val = v3.length > 1 ? v3 : `0${v3}`;
+            let val = v3;
+            const maxDigits = vFormatArr[verArr.length - 1] || 2;
+            if (v3.length > maxDigits) {
+                val = v3.substr(0, maxDigits);
+            } else if (v3.length < maxDigits) {
+                let toAdd = maxDigits - v3.length;
+                while (toAdd > 0) {
+                    val = `0${v3}`;
+                    toAdd--;
+                }
+            }
             verArr.push(val);
         }
     })));
-    let verCountDiff = versionNumberMaxCount - verArr.length;
+    let verCountDiff = versionCodeMaxCount - verArr.length;
     if (verCountDiff) {
         while (verCountDiff > 0) {
             verArr.push('00');

--- a/packages/rnv/src/core/common.js
+++ b/packages/rnv/src/core/common.js
@@ -331,11 +331,17 @@ export const getAppVersionCode = (c, platform) => {
             verArr.push(val);
         }
     })));
-    let verCountDiff = versionCodeMaxCount - verArr.length;
-    if (verCountDiff) {
-        while (verCountDiff > 0) {
-            verArr.push('00');
-            verCountDiff--;
+    let verCountDiff = verArr.length - versionCodeMaxCount;
+    if (verCountDiff < 0) {
+        while (verCountDiff < 0) {
+            let extraVersionLen = vFormatArr[versionCodeMaxCount + verCountDiff];
+            let num = '';
+            while (extraVersionLen) {
+                num += '0';
+                extraVersionLen--;
+            }
+            verArr.push(num);
+            verCountDiff++;
         }
     }
     const output = Number(verArr.join('')).toString();

--- a/packages/rnv/src/core/common.js
+++ b/packages/rnv/src/core/common.js
@@ -308,17 +308,26 @@ export const getAppDescription = (c, platform) => getConfigProp(c, platform, 'de
 export const getAppVersionCode = (c, platform) => {
     const versionCode = getConfigProp(c, platform, 'versionCode');
     if (versionCode) return versionCode;
-
     const version = getAppVersion(c, platform);
-
-    let vc = '';
-    version
-        .split('-')[0]
-        .split('.')
-        .forEach((v) => {
-            vc += v.length > 1 ? v : `0${v}`;
-        });
-    return Number(vc).toString();
+    const versionNumberMaxCount = getConfigProp(c, platform, 'versionCodeMaxCount', 3);
+    const verArr = [];
+    version.split('.').map(v => v.split('-').map(v2 => v2.split('+').forEach((v3) => {
+        const asNumber = Number(v3);
+        if (!Number.isNaN(asNumber)) {
+            const val = v3.length > 1 ? v3 : `0${v3}`;
+            verArr.push(val);
+        }
+    })));
+    let verCountDiff = versionNumberMaxCount - verArr.length;
+    if (verCountDiff) {
+        while (verCountDiff > 0) {
+            verArr.push('00');
+            verCountDiff--;
+        }
+    }
+    const output = Number(verArr.join('')).toString();
+    // console.log(`IN: ${version}\nOUT: ${output}`);
+    return output;
 };
 
 export const isMonorepo = () => {

--- a/packages/rnv/tests/unitTests/common.test.js
+++ b/packages/rnv/tests/unitTests/common.test.js
@@ -1,0 +1,132 @@
+import { getAppVersionCode } from '../../src/core/common';
+
+jest.mock('../../src/core/systemManager/logger.js', () => {
+    const _chalkCols = {
+        white: v => v,
+        green: v => v,
+        red: v => v,
+        yellow: v => v,
+        default: v => v,
+        gray: v => v,
+        grey: v => v,
+        blue: v => v,
+        cyan: v => v,
+        magenta: v => v
+    };
+    _chalkCols.rgb = () => v => v;
+    _chalkCols.bold = _chalkCols;
+    const _chalkMono = {
+        ..._chalkCols
+    };
+    return {
+        logToSummary: jest.fn(),
+        logTask: jest.fn(),
+        logDebug: jest.fn(),
+        logInfo: jest.fn(),
+        logError: jest.fn(),
+        logWarning: jest.fn(),
+        logSuccess: jest.fn(),
+        chalk: () => _chalkMono
+    };
+});
+
+// TO TEST:
+// 0.0.4
+// 1.2.3
+// 10.20.30
+// 1.1.2-prerelease+meta
+// 1.1.2+meta
+// 1.1.2+meta-valid
+// 1.0.0-alpha
+// 1.0.0-beta
+// 1.0.0-alpha.beta
+// 1.0.0-alpha.beta.1
+// 1.0.0-alpha.1
+// 1.0.0-alpha0.valid
+// 1.0.0-alpha.0valid
+// 1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay
+// 1.0.0-rc.1+build.1
+// 2.0.0-rc.1+build.123
+// 1.2.3-beta
+// 10.2.3-DEV-SNAPSHOT
+// 1.2.3-SNAPSHOT-123
+// 1.0.0
+// 2.0.0
+// 1.1.7
+// 2.0.0+build.1848
+// 2.0.1-alpha.1227
+// 1.0.0-alpha+beta
+// 1.2.3----RC-SNAPSHOT.12.9.1--.12+788
+// 1.2.3----R-S.12.9.1--.12+meta
+// 1.2.3----RC-SNAPSHOT.12.9.1--.12
+// 1.0.0+0.build.1-rc.10000aaa-kk-0.1
+// 99999999999999999999999.999999999999999999.99999999999999999
+// 1.0.0-0A.is.legal
+
+const BUILD_CONF = {
+  runtime: {
+    scheme: 'debug'
+  },
+  buildConfig: {
+    common: {
+
+    }
+  }
+}
+
+describe('Testing getAppVersionCode functions', () => {
+    it('should evaluate 1.2.3', async () => {
+        const result = getAppVersionCode({ ...BUILD_CONF, files: { project: { package: { version: '1.2.3' }}}});
+        expect(result).toEqual('10203');
+    });
+
+    it('should evaluate 1.2.3 with 00.00.00.00.00', async () => {
+        const result = getAppVersionCode({
+          ...BUILD_CONF,
+          buildConfig: { common: { versionCodeFormat: '00.00.00.00.00' }},
+          files: { project: { package: { version: '1.2.3' }}}});
+        expect(result).toEqual('102030000');
+    });
+
+    it('should evaluate 2.0.0+build.1848', async () => {
+        const result = getAppVersionCode({ ...BUILD_CONF, files: { project: { package: { version: '2.0.0+build.1848' }}}});
+        expect(result).toEqual('2000018');
+    });
+
+    it('should evaluate 2.0.0+build.1848 with 00.00.0000', async () => {
+        const result = getAppVersionCode({
+          ...BUILD_CONF,
+          buildConfig: { common: { versionCodeFormat: '00.00.0000' }},
+          files: { project: { package: { version: '2.0.0+build.1848' }}}});
+        expect(result).toEqual('200001848');
+    });
+
+    it('should evaluate 1.0.0-alpha+beta', async () => {
+        const result = getAppVersionCode({ ...BUILD_CONF, files: { project: { package: { version: '1.0.0-alpha+beta' }}}});
+        expect(result).toEqual('10000');
+    });
+
+    it('should evaluate 999999999999.99999999999.9999999', async () => {
+        const result = getAppVersionCode({ ...BUILD_CONF, files: { project: { package: { version: '999999999999.99999999999.9999999' }}}});
+        expect(result).toEqual('999999');
+    });
+
+    it('should evaluate 2.0.1-alpha.1227', async () => {
+        const result = getAppVersionCode({ ...BUILD_CONF, files: { project: { package: { version: '2.0.1-alpha.1227' }}}});
+        expect(result).toEqual('2000112');
+    });
+
+    it('should evaluate 2.0.1-alpha.1227', async () => {
+        const result = getAppVersionCode({
+          ...BUILD_CONF,
+          buildConfig: { common: { versionCodeFormat: '00.00.0000' }},
+          files: { project: { package: { version: '2.0.1-alpha.1227' }}}});
+        expect(result).toEqual('200011227');
+    });
+
+    it('should evaluate 1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay', async () => {
+        const result = getAppVersionCode({ ...BUILD_CONF, files: { project: { package: { version: '1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay' }}}});
+        expect(result).toEqual('100000101');
+    });
+
+});

--- a/packages/rnv/tests/unitTests/common.test.js
+++ b/packages/rnv/tests/unitTests/common.test.js
@@ -129,4 +129,33 @@ describe('Testing getAppVersionCode functions', () => {
         expect(result).toEqual('100000101');
     });
 
+    it('should evaluate 1.0.1-beta+exp.sha.5114f85', async () => {
+        const result = getAppVersionCode({ ...BUILD_CONF, files: { project: { package: { version: '1.0.1-beta+exp.sha.5114f85' }}}});
+        expect(result).toEqual('10001');
+    });
+
+    it('should evaluate 1.0.1-beta+exp.sha.5114f85 with 00.00.00.00.00.00', async () => {
+        const result = getAppVersionCode({
+          ...BUILD_CONF,
+          buildConfig: { common: { versionCodeFormat: '00.00.00.00.00.00' }},
+          files: { project: { package: { version: '1.0.1-beta+exp.sha.5114f85' }}}});
+        expect(result).toEqual('10001000000');
+    });
+
+    it('should evaluate 1.0.1-beta+exp.sha.5114f85 with 00.00.00.000000', async () => {
+        const result = getAppVersionCode({
+          ...BUILD_CONF,
+          buildConfig: { common: { versionCodeFormat: '00.00.00.000000' }},
+          files: { project: { package: { version: '1.0.1-beta+exp.sha.5114f85' }}}});
+        expect(result).toEqual('10001000000');
+    });
+
+    it('should evaluate 1', async () => {
+        const result = getAppVersionCode({
+          ...BUILD_CONF,
+          files: { project: { package: { version: '1' }}}});
+        expect(result).toEqual('10000');
+    });
+
+
 });


### PR DESCRIPTION
## Description 

add support for complex package versions in getAppVersionCode 


0.0.4
1.2.3
10.20.30
1.1.2-prerelease+meta
1.1.2+meta
1.1.2+meta-valid
1.0.0-alpha
1.0.0-beta
1.0.0-alpha.beta
1.0.0-alpha.beta.1
1.0.0-alpha.1
1.0.0-alpha0.valid
1.0.0-alpha.0valid
1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay
1.0.0-rc.1+build.1
2.0.0-rc.1+build.123
1.2.3-beta
10.2.3-DEV-SNAPSHOT
1.2.3-SNAPSHOT-123
1.0.0
2.0.0
1.1.7
2.0.0+build.1848
2.0.1-alpha.1227
1.0.0-alpha+beta
1.2.3----RC-SNAPSHOT.12.9.1--.12+788
1.2.3----R-S.12.9.1--.12+meta
1.2.3----RC-SNAPSHOT.12.9.1--.12
1.0.0+0.build.1-rc.10000aaa-kk-0.1
99999999999999999999999.999999999999999999.99999999999999999
1.0.0-0A.is.legal

### Examples:

-------------
IN: 1.2.3-rc.4+build.56
OUT: 102030456

IN: 1.2.3
OUT: 10203

-------------

"versionCodeFormat" : "00.00.00.00.00"

IN: 1.2.3-rc.4+build.56
OUT: 102030456

IN: 1.2.3
OUT: 102030000

--------------

## Breaking Changes

none
    
