### PR TITLE
allow users to controll appShell html headers

### DIFF
--- a/packages/rnv/src/engine-rn-web/tasks/task.rnv.run.js
+++ b/packages/rnv/src/engine-rn-web/tasks/task.rnv.run.js
@@ -28,6 +28,7 @@ const _configureHostedIfRequired = async (c) => {
     logTask('_configureHostedIfRequired');
 
     const bundleAssets = getConfigProp(c, c.platform, 'bundleAssets', false);
+    const hostedShellHeaders = getConfigProp(c, c.platform, 'hostedShellHeaders', '');
 
     if (!bundleAssets) {
         logDebug('Running hosted build');
@@ -39,7 +40,11 @@ const _configureHostedIfRequired = async (c) => {
                 {
                     pattern: '{{DEV_SERVER}}',
                     override: `http://${ip.address()}:${c.runtime.port}`
-                }
+                },
+                {
+                    pattern: '{{APPSHELL_HTML_HEADER}}',
+                    override: String(hostedShellHeaders || '')
+                },
             ], null, c
         );
     }

--- a/packages/rnv/supportFiles/appShell/index.html
+++ b/packages/rnv/supportFiles/appShell/index.html
@@ -8,6 +8,7 @@
       background-color: white;
     }
   </style>
+  {{APPSHELL_HTML_HEADER}}
 </head>
 
 <body style="margin:0px;padding:0px;overflow:hidden">


### PR DESCRIPTION
## Description 

When building TV Apps, developers often need to control the viewport of the app, i.e. to render the app at 720p/1080p and the the OS scale the rest. This can be achieved by setting `<meta name="viewport" content="width=1280" />`

However, when using a hosted build in development, the `appShell/index.html` does not include any viewport tags.

This can now be controlled using the following in the renative.json.

```
"platforms": {
    "tizen": {
        "hostedShellHeaders": "<meta name=\"viewport\" content=\"width=1280\" />"
    }
  }
```

I am open to suggestions, especially about the naming and scope. 
In an ideal world, there would be one viewport setting which is also applied inside the webpack configurations, but this seems to be a huge change. Every platform has its own webpack config and I could not find an example to access renative.json values from the webpack config.