### PR TITLE
Link ios & android slider packages

### DIFF
--- a/packages/rnv/pluginTemplates/renative.plugins.json
+++ b/packages/rnv/pluginTemplates/renative.plugins.json
@@ -2364,7 +2364,14 @@
             }
         },
         "@react-native-community/slider": {
-            "version": "2.0.2"
+            "version": "3.0.3",
+            "ios": {
+                "podName": "react-native-slider"
+            },
+            "android": {
+                "path": "node_modules/@react-native-community/slider/android",
+                "package": "com.reactnativecommunity.slider.ReactSliderPackage"
+            }
         },
         "react-native-render-html": {
             "version": "4.1.1",


### PR DESCRIPTION
## Description 

This will fix the error:
> "Invariant Violation: Invariant Violation: Invariant Violation: requireNativeComponent: "RNCSlider" was not found in the UIManager." 

When importing 'Slider' component from the "react-native-community/slider".

## Breaking Changes

Should not introduce breaking changes to existing functionality.
    
 ## I have tested my changes on:
 
 ReNative project directly:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

New project:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

Existing Project created with previous version of renative:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
