### PR TITLE
enable configure webos appinfo.json

### DIFF
--- a/packages/rnv/src/engine-rn-web/platformTemplates/webos/project/appinfo.json
+++ b/packages/rnv/src/engine-rn-web/platformTemplates/webos/project/appinfo.json
@@ -1,10 +1,14 @@
 {
-    "vendor": "Pavel Jacko",
-    "largeIcon": "largeIcon.png",
+    "appDescription": "{{APP_DESCRIPTION}}",
+    "bgColor": "{{APP_BG_COLOR}}",
     "icon": "icon.png",
-    "main": "index.html",
+    "iconColor": "{{APP_ICON_COLOR}}",
     "id": "{{APPLICATION_ID}}",
+    "largeIcon": "largeIcon.png",
+    "main": "index.html",
+    "splashBackground": "splashBackground.png",
     "title": "{{APP_TITLE}}",
     "type": "web",
+    "vendor": "{{APP_VENDOR}}",
     "version": "{{APP_VERSION}}"
 }

--- a/packages/rnv/src/sdk-webos/index.js
+++ b/packages/rnv/src/sdk-webos/index.js
@@ -15,6 +15,7 @@ import {
     // getAppTemplateFolder,
     getAppTitle,
     getAppId,
+    getAppDescription,
     // getAppTemplateFolder,
     getConfigProp,
     checkPortInUse,
@@ -388,6 +389,22 @@ const configureProject = async (c) => {
         {
             pattern: '{{APP_VERSION}}',
             override: semver.coerce(getAppVersion(c, platform))
+        },
+        {
+            pattern: '{{APP_DESCRIPTION}}',
+            override: getAppDescription(c, platform)
+        },
+        {
+            pattern: '{{APP_BG_COLOR}}',
+            override: getConfigProp(c, platform, 'bgColor', '#fff')
+        },
+        {
+            pattern: '{{APP_ICON_COLOR}}',
+            override: getConfigProp(c, platform, 'iconColor', '#000')
+        },
+        {
+            pattern: '{{APP_VENDOR}}',
+            override: getConfigProp(c, platform, 'vendor', 'Pavel Jacko')
         }
     ];
 


### PR DESCRIPTION
## Description 

This will allow to almost fully configure app metadata according to official specification: http://webostv.developer.lge.com/develop/app-developer-guide/app-metadata/

## Breaking Changes

- PRs should not introduce breaking changes to existing functionality 
    
 ## I have tested my changes on:
 
 ReNative project directly:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [x] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

New project:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

Existing Project created with previous version of renative:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
