### PR TITLE
allow custom config.xml for Tizen

### DIFF
--- a/packages/rnv/src/sdk-tizen/index.js
+++ b/packages/rnv/src/sdk-tizen/index.js
@@ -614,9 +614,11 @@ export const configureProject = c => new Promise((resolve) => {
 
     addSystemInjects(c, injects);
 
+    // the file should already be copied via copyAssets, same input and output fil
+    const file = path.join(getPlatformProjectDir(c), configFile);
     writeCleanFile(
-        path.join(getTemplateProjectDir(c), configFile),
-        path.join(getPlatformProjectDir(c), configFile),
+        file,
+        file,
         injects, null, c
     );
 

--- a/packages/rnv/src/sdk-tizen/index.js
+++ b/packages/rnv/src/sdk-tizen/index.js
@@ -614,7 +614,7 @@ export const configureProject = c => new Promise((resolve) => {
 
     addSystemInjects(c, injects);
 
-    // the file should already be copied via copyAssets, same input and output fil
+    // the file should already be copied via copyAssets, same input and output file
     const file = path.join(getPlatformProjectDir(c), configFile);
     writeCleanFile(
         file,


### PR DESCRIPTION
## Description 

It was not possible to provide a custom config.xml, because the configure step would override the end result with the template. This resolves it and allows for variable replacement in the config.

## Breaking Changes
None 
 ## I have tested my changes on:
 
 ReNative project directly:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [x] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
