### PR TITLE
Android based platforms use kotlin 1.3.50

### DIFF
--- a/packages/rnv-engine-rn/templates/platforms/androidtv/build.gradle
+++ b/packages/rnv-engine-rn/templates/platforms/androidtv/build.gradle
@@ -3,7 +3,7 @@
 import groovy.json.JsonSlurper
 
 buildscript {
-    ext.kotlin_version = '1.3.20'
+    ext.kotlin_version = '1.3.50'
     repositories {
         google()
         jcenter()

--- a/packages/rnv-engine-rn/templates/platforms/androidwear/build.gradle
+++ b/packages/rnv-engine-rn/templates/platforms/androidwear/build.gradle
@@ -3,7 +3,7 @@
 import groovy.json.JsonSlurper
 
 buildscript {
-    ext.kotlin_version = '1.3.20'
+    ext.kotlin_version = '1.3.50'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
## Description 

ATV and Wear templates used older version of Kotlin, than main Android template, unified 

## Breaking Changes

none
    
 ## I have tested my changes on:
 
 ReNative project directly:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

New project:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

Existing Project created with previous version of renative:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
