### PR TITLE
feat(xcode): Added EXCLUDED_ARCHS support for specific build targets

### DIFF
--- a/packages/rnv-engine-rn/src/sdks/sdk-xcode/xcodeParser.js
+++ b/packages/rnv-engine-rn/src/sdks/sdk-xcode/xcodeParser.js
@@ -168,10 +168,28 @@ const _parseXcodeProject = (c, platform) => new Promise((resolve) => {
         }
 
         if (excludedArchs) {
-            xcodeProj.updateBuildProperty(
-                'EXCLUDED_ARCHS',
-                `"${excludedArchs.join(' ')}"`
-            );
+            const tempExcludedArchs = [];
+
+            if (typeof excludedArchs.forEach === 'function') {
+                excludedArchs.forEach((arch) => {
+                    if (typeof arch === 'string') tempExcludedArchs.push(arch);
+                    if (typeof arch === 'object') {
+                        Object.keys(arch).forEach((key) => {
+                            xcodeProj.updateBuildProperty(
+                                `"EXCLUDED_ARCHS[${key}]"`,
+                                `"${arch[key]}"`
+                            );
+                        });
+                    }
+                });
+            }
+
+            if (tempExcludedArchs.length) {
+                xcodeProj.updateBuildProperty(
+                    'EXCLUDED_ARCHS',
+                    `"${tempExcludedArchs.join(' ')}"`
+                );
+            }
         }
 
 


### PR DESCRIPTION
## Description 

This PR adds support for EXCLUDED_ARCHS only for specific build targets. This is needed in order to exclude for example `amd64` arch for simulators only.

Example buildScheme using this change
```
"buildSchemes": {
    "debug": {
        "excludedArchs": [{
            "sdk=iphonesimulator*": "arm64"
        }]
    }
}
```

Results in following output in `project.pbxproj`:
```
"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64";
```

## Breaking Changes

- PRs should not introduce breaking changes to existing functionality 
- if breaking change cannot be avoided it has to be introduced in 2 phases (release cycles of 0.x.0)
    - `0.x.0` Add new functionality + add `DEPRECATED` warning to existing fuctionality
    - `0.[x+1].0` Remove deprecated functionality
    
 ## I have tested my changes on:
 
 ReNative project directly:
 
* [x] ios simulator (run, build, archive)
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

New project:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

Existing Project created with previous version of renative:
 
* [x] ios simulator (run, build, archive => SOTT)
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
