### PR TITLE
WIP: Add support for Tic Watch Pro 3, as well as BLE on androidwear and ios

### DIFF
--- a/packages/rnv/pluginTemplates/renative.plugins.json
+++ b/packages/rnv/pluginTemplates/renative.plugins.json
@@ -1756,6 +1756,9 @@
             "android": {
                 "package": "it.innove.BleManagerPackage"
             },
+            "androidwear": {
+                "package": "it.innove.BleManagerPackage"
+            },
             "androidtv": {
                 "package": "it.innove.BleManagerPackage"
             },

--- a/packages/rnv/pluginTemplates/renative.plugins.json
+++ b/packages/rnv/pluginTemplates/renative.plugins.json
@@ -1752,7 +1752,7 @@
             }
         },
         "react-native-ble-manager": {
-            "version": "6.2.4",
+            "version": "7.4.2",
             "android": {
                 "package": "it.innove.BleManagerPackage"
             },
@@ -1763,6 +1763,9 @@
                 "package": "it.innove.BleManagerPackage"
             },
             "firetv": {
+                "package": "it.innove.BleManagerPackage"
+            },
+            "ios": {
                 "package": "it.innove.BleManagerPackage"
             }
         },

--- a/packages/rnv/src/core/sdkManager/deviceUtils/android.js
+++ b/packages/rnv/src/core/sdkManager/deviceUtils/android.js
@@ -281,7 +281,8 @@ const decideIfWearRunning = async (c, device) => {
     let isWear = false;
     [fingerprint, name, mod, flavor, description, model, product].forEach(
         (string) => {
-            if (string && string.toLowerCase().includes('wear')) isWear = true;
+            const cmp = string ? string.toLowerCase() : ''
+            if ((cmp.includes('wear') || cmp.includes('rubyfish'))) isWear = true;
         }
     );
     return isWear;

--- a/packages/rnv/src/core/sdkManager/deviceUtils/android.js
+++ b/packages/rnv/src/core/sdkManager/deviceUtils/android.js
@@ -281,7 +281,7 @@ const decideIfWearRunning = async (c, device) => {
     let isWear = false;
     [fingerprint, name, mod, flavor, description, model, product].forEach(
         (string) => {
-            const cmp = string ? string.toLowerCase() : ''
+            const cmp = string ? string.toLowerCase() : '';
             if ((cmp.includes('wear') || cmp.includes('rubyfish'))) isWear = true;
         }
     );


### PR DESCRIPTION
## Description 

This pull is intended to resolve #664, in addition to declaring react-native-ble-manager works on WearOS devices with BLE.

- Currently the code for detecting WearOS/Android Wear devices is too strict. Added support for detecting Tic Watch Pro 3 by looking for "rubysail" in addition to "wear"
- Added support for react-native-ble-manager to `androidwear` and `ios`. IOS is explicitly supported, and I was able to use the library on my Tic Watch Pro 3
- Upgraded react-native-ble-manager from 6.2.4 to 7.4.2

## Breaking Changes

- I did upgrade react-native-ble-manager to a new major version. I can roll this back to 6.2.4 though if this is an issue. I assume it is fine because the next release will be a breaking change anyways (0.31 -> 0.32), even though a major version dependency change is generally treated as breaking. 
    
 ## I have tested my changes on:

I call this WIP because I cannot test this directly. See #665. However, I did test the same changes made manually in 0.31.3 against an android device. BLE cannot be tested in simulator. I do not have access to an IOS device to test (yet); however, because it is documented to be supported by react-native-ble-manager, I assumed it was safe to add support here for it.
 
 ReNative project directly:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

New project:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

Existing Project created with previous version of renative:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
