### PR TITLE
[ReNative][Run-Android]let adb connect devices's adb not be reset

### DIFF
--- a/packages/rnv-engine-rn/src/sdks/sdk-android/index.js
+++ b/packages/rnv-engine-rn/src/sdks/sdk-android/index.js
@@ -156,8 +156,6 @@ export const runAndroid = async (c, defaultTarget) => {
     // shortcircuit devices logic since aabs can't be installed on a device
     if (outputAab) return _runGradleApp(c, platform, {});
 
-    await resetAdb(c);
-
     if (target && net.isIP(target)) {
         await connectToWifiDevice(c, target);
     }
@@ -176,7 +174,11 @@ export const runAndroid = async (c, defaultTarget) => {
 
     const activeDevices = devicesAndEmulators.filter(d => d.isActive);
     const inactiveDevices = devicesAndEmulators.filter(d => !d.isActive);
-
+	
+    if (activeDevices.length !== 1){
+        await resetAdb(c);
+    }
+	
     const askWhereToRun = async () => {
         if (activeDevices.length === 0 && inactiveDevices.length > 0) {
             // No device active, but there are emulators created


### PR DESCRIPTION
## Description 

- Describe the nature of the work / fix

adb connect 127.0.0.1:21503
rnv run
select andriod mode ,
then the adb connected be killed ,cannot find the deivice before the codes changed.

Detail info:
C:\Users\Administrator>adb connect 127.0.0.1:21503
adb server version (31) doesn't match this client (41); killing...
* daemon started successfully
connected to 127.0.0.1:21503

C:\Users\Administrator>adb devices -l
List of devices attached
127.0.0.1:21503        device product:HD1910 model:HD1910 device:HD1910 transport_id:1
C:\Users\Administrator\project>rnv run -p android
……
[ task ] [run] runAndroid[1] target:undefined default:undefined
[ task ] [run] getAndroidTargets[1] skipDevices:false skipAvds:false deviceOnly:false
√ Executing: E:\devEnv\androidSDK\platform-tools\adb.exe devices -l
√ Executing: E:\devEnv\androidSDK\emulator\emulator.exe -list-avds
√ Executing: E:\devEnv\androidSDK\platform-tools\adb.exe -s 127.0.0.1:21503 shell wm size
√ Executing: E:\devEnv\androidSDK\platform-tools\adb.exe -s 127.0.0.1:21503 shell wm density
√ Executing: E:\devEnv\androidSDK\platform-tools\adb.exe -s 127.0.0.1:21503 shell getprop
[ info ] [run] Found device HD1910:127.0.0.1:21503!
[ task ] [run] _runGradleApp[1]
[ task ] [run] _checkSigningCerts[1]
√ Executing: gradlew.bat assembleDebug -x bundleReleaseJsAndAssets
……
## Breaking Changes


- PRs should not introduce breaking changes to existing functionality 
- if breaking change cannot be avoided it has to be introduced in 2 phases (release cycles of 0.x.0)
    - `0.x.0` Add new functionality + add `DEPRECATED` warning to existing fuctionality
    - `0.[x+1].0` Remove deprecated functionality
    
 ## I have tested my changes on:
 
 ReNative project directly:
 
* [ ] ios simulator
* [ ] ios device
* [x] android simulator
[*  ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

New project:
 
* [ ] ios simulator
* [ ] ios device
* [x] android simulator
[*  ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

Existing Project created with previous version of renative:
 
* [ ] ios simulator
* [ ] ios device
* [x] android simulator
[*  ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
