### PR TITLE
[fix] resolve paths in monorepo projects

### DIFF
--- a/packages/rnv/pluginTemplates/@react-native-community/cli/overrides/build/commands/bundle/getAssetDestPathIOS.js
+++ b/packages/rnv/pluginTemplates/@react-native-community/cli/overrides/build/commands/bundle/getAssetDestPathIOS.js
@@ -1,0 +1,38 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+function _path() {
+  const data = _interopRequireDefault(require("path"));
+
+  _path = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+function getAssetDestPathIOS(asset, scale) {
+  const suffix = scale === 1 ? '' : `@${scale}x`;
+  const fileName = `${asset.name + suffix}.${asset.type}`;
+
+  return _path().default.join(
+    asset.httpServerLocation.substr(1).replace(/\.\.\//g, '_'),
+    fileName,
+  );
+}
+
+var _default = getAssetDestPathIOS;
+exports.default = _default;

--- a/packages/rnv/pluginTemplates/react-native/overrides@0.61.2.json
+++ b/packages/rnv/pluginTemplates/react-native/overrides@0.61.2.json
@@ -2,6 +2,9 @@
   "overrides": {
     "Libraries/Image/RCTUIImageViewAnimated.m": {
       "_currentFrame.CGImage;": "_currentFrame.CGImage ;} else { [super displayLayer:layer];"
+    },
+    "Libraries/Image/AssetSourceResolver.js": {
+      "this.fromSource(path + getScaledAssetPath(this.asset));": "this.fromSource(path + getScaledAssetPath(this.asset).replace(/\\.\\.\\//g, '_'));"
     }
   }
 }


### PR DESCRIPTION
## Description 

It's an override of same fix done on [react-native](https://github.com/facebook/react-native/pull/27932) and [react-native-community/cli](https://github.com/react-native-community/cli/pull/939).

Original summary of fix:

> When an asset is outside of the metro project root, it can lead to relative paths like /assets/../../node_modules/coolpackage/image.png as the httpServerLocation. This can happen for example when using yarn workspaces with hoisted node_modules.
> 
> This causes issues when bundling on iOS since we use this path in the filesystem. To avoid this we replace ../ with _ to preserve the uniqueness of the path while avoiding these kind of problematic relative paths. The same logic is used when bundling assets in the rn-cli.

It's easily visible/testable on monorepo projects which uses react-navigation. Header back icon is not visible without this fix.
    
 ## I have tested my changes on:
 
 ReNative project directly:
 
* [x] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

Existing Project created with previous version of renative:
 
* [x] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
