### PR TITLE
fix: navigating home from navigation drawer in Android Hello World template

### DIFF
--- a/packages/renative-template-hello-world/src/config.js
+++ b/packages/renative-template-hello-world/src/config.js
@@ -147,7 +147,7 @@ export const themeStyles = StyleSheet.create({
 });
 
 export const ROUTES = {
-    HOME: '/',
+    HOME: 'home',
     MY_PAGE: 'my-page',
     MODAL: 'modal'
 };


### PR DESCRIPTION
## Description 

- Describe the nature of the work / fix

I start work at 24i on Monday and thought I should try out Renative! Spun up the Android hello world template and found this bug in the navigation:

Router throws an error when navigating from the navigation draw to home

![Screenshot 2021-07-02 at 15 25 45](https://user-images.githubusercontent.com/33122888/124288050-048b3d00-db51-11eb-8ba1-f4c751f0f89f.png)

Now when clicking home in from the drawer, the draw closes and the user can navigate home.

## Breaking Changes

- PRs should not introduce breaking changes to existing functionality 
- if breaking change cannot be avoided it has to be introduced in 2 phases (release cycles of 0.x.0)
    - `0.x.0` Add new functionality + add `DEPRECATED` warning to existing fuctionality
    - `0.[x+1].0` Remove deprecated functionality
    
 ## I have tested my changes on:
 
 ReNative project directly:
 
* [ ] ios simulator
* [ ] ios device
* [x] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

New project:
 
* [ ] ios simulator
* [ ] ios device
* [x] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

Existing Project created with previous version of renative:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
