### PR TITLE
feat: additional config property `monoRoot`

### DIFF
--- a/packages/rnv/src/core/engineManager/index.js
+++ b/packages/rnv/src/core/engineManager/index.js
@@ -253,7 +253,8 @@ const _resolvePkgPath = (c, packageName) => {
     if (fsExistsSync(pkgPath)) {
         return pkgPath;
     }
-    pkgPath = path.join(c.paths.project.dir, '../..', 'node_modules', packageName);
+    const monoRoot = getConfigProp(c, c.platform, 'monoRoot');
+    pkgPath = path.join(c.paths.project.dir, monoRoot || '../..', 'node_modules', packageName);
     if (fsExistsSync(pkgPath)) {
         return pkgPath;
     }
@@ -297,6 +298,7 @@ Maybe you forgot to define platforms.${platform}.engine in your renative.json?`)
 
 export const generateEnvVars = (c, moduleConfig, nextConfig) => {
     const isMonorepo = getConfigProp(c, c.platform, 'isMonorepo');
+    const monoRoot = getConfigProp(c, c.platform, 'monoRoot');
 
     return ({
         RNV_EXTENSIONS: getPlatformExtensions(c),
@@ -306,7 +308,7 @@ export const generateEnvVars = (c, moduleConfig, nextConfig) => {
         RNV_PROJECT_ROOT: c.paths.project.dir,
         RNV_APP_BUILD_DIR: getAppFolder(c),
         RNV_IS_MONOREPO: isMonorepo,
-        RNV_MONO_ROOT: (c.runtime.isWrapper || isMonorepo) ? path.join(c.paths.project.dir, '../..') : c.paths.project.dir,
+        RNV_MONO_ROOT: (c.runtime.isWrapper || isMonorepo) ? path.join(c.paths.project.dir, monoRoot || '../..') : c.paths.project.dir,
         RNV_ENGINE: c.runtime.engine.config.id,
         RNV_IS_NATIVE_TV: [TVOS, ANDROID_TV, FIRE_TV].includes(c.platform)
     });

--- a/packages/rnv/src/core/schemaManager/schemaRenativeJson.js
+++ b/packages/rnv/src/core/schemaManager/schemaRenativeJson.js
@@ -1742,6 +1742,11 @@ IN: 1.0.23 OUT: 100230000
         isMonorepo: {
             type: 'boolean',
         },
+        monoRepo: {
+            type: 'string',
+            description: 'Define custom path to monorepo root where starting point is project directory',
+            example: '../../..'
+        },
         enableAnalytics: {
             type: 'boolean',
             description: 'Enable or disable sending analytics to improve ReNative',


### PR DESCRIPTION
Idea is to have additional config prop named something like `monoRoot` to be able to set the path for monorepo root directory manually. 

So if app is under `packages/apps/myapplication`, you need to go 3 directories back (`../../..`) to reach monorepo root instead of going 2 directories back (`../..` which is default right now) when the app is under `packages/myapplication`.

Not having this causes multiple issues in our project.

It's just a rough idea what I'm trying to accomplish, so it would be good to know if there is something you'd change