### PR TITLE
added support for kotlin version inject

### DIFF
--- a/packages/rnv-engine-rn-tvos/src/sdks/sdk-android/gradleParser.js
+++ b/packages/rnv-engine-rn-tvos/src/sdks/sdk-android/gradleParser.js
@@ -55,6 +55,11 @@ export const parseBuildGradleSync = (c) => {
                 c.pluginConfigAndroid.buildGradleBuildScriptRepositories
         },
         {
+            pattern: '{{INJECT_KOTLIN_VERSION}}',
+            override:
+                c.pluginConfigAndroid.kotlinVersion || '1.3.0'
+        },
+        {
             pattern: '{{INJECT_PLUGINS}}',
             override:
                 c.pluginConfigAndroid.buildGradlePlugins

--- a/packages/rnv-engine-rn-tvos/templates/platforms/androidtv/build.gradle
+++ b/packages/rnv-engine-rn-tvos/templates/platforms/androidtv/build.gradle
@@ -3,7 +3,7 @@
 import groovy.json.JsonSlurper
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '{{INJECT_KOTLIN_VERSION}}'
     repositories {
         google()
         jcenter()

--- a/packages/rnv-engine-rn-tvos/templates/platforms/firetv/build.gradle
+++ b/packages/rnv-engine-rn-tvos/templates/platforms/firetv/build.gradle
@@ -3,7 +3,7 @@
 import groovy.json.JsonSlurper
 
 buildscript {
-    ext.kotlin_version = '1.3.20'
+    ext.kotlin_version = '{{INJECT_KOTLIN_VERSION}}'
     repositories {
         google()
         jcenter()

--- a/packages/rnv-engine-rn/src/sdks/sdk-android/gradleParser.js
+++ b/packages/rnv-engine-rn/src/sdks/sdk-android/gradleParser.js
@@ -56,6 +56,11 @@ export const parseBuildGradleSync = (c) => {
                 c.pluginConfigAndroid.buildGradleBuildScriptRepositories
         },
         {
+            pattern: '{{INJECT_KOTLIN_VERSION}}',
+            override:
+                c.pluginConfigAndroid.kotlinVersion || '1.3.0'
+        },
+        {
             pattern: '{{INJECT_PLUGINS}}',
             override:
                 c.pluginConfigAndroid.buildGradlePlugins

--- a/packages/rnv-engine-rn/templates/platforms/android/build.gradle
+++ b/packages/rnv-engine-rn/templates/platforms/android/build.gradle
@@ -3,7 +3,7 @@
 import groovy.json.JsonSlurper
 
 buildscript {
-    ext.kotlin_version = '1.3.0'
+    ext.kotlin_version = '{{INJECT_KOTLIN_VERSION}}'
     ext.kotlinVersion = "$kotlin_version"
     repositories {
         google()

--- a/packages/rnv-engine-rn/templates/platforms/androidtv/build.gradle
+++ b/packages/rnv-engine-rn/templates/platforms/androidtv/build.gradle
@@ -3,7 +3,7 @@
 import groovy.json.JsonSlurper
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '{{INJECT_KOTLIN_VERSION}}'
     repositories {
         google()
         jcenter()

--- a/packages/rnv-engine-rn/templates/platforms/androidwear/build.gradle
+++ b/packages/rnv-engine-rn/templates/platforms/androidwear/build.gradle
@@ -3,7 +3,7 @@
 import groovy.json.JsonSlurper
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '{{INJECT_KOTLIN_VERSION}}'
     repositories {
         google()
         jcenter()

--- a/packages/rnv-engine-rn/templates/platforms/firetv/build.gradle
+++ b/packages/rnv-engine-rn/templates/platforms/firetv/build.gradle
@@ -3,7 +3,7 @@
 import groovy.json.JsonSlurper
 
 buildscript {
-    ext.kotlin_version = '1.3.20'
+    ext.kotlin_version = '{{INJECT_KOTLIN_VERSION}}'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
## Description 

- Describe the nature of the work / fix

## Breaking Changes

- PRs should not introduce breaking changes to existing functionality 
- if breaking change cannot be avoided it has to be introduced in 2 phases (release cycles of 0.x.0)
    - `0.x.0` Add new functionality + add `DEPRECATED` warning to existing fuctionality
    - `0.[x+1].0` Remove deprecated functionality
    
 ## I have tested my changes on:
 
 ReNative project directly:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

New project:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

Existing Project created with previous version of renative:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
