### PR TITLE
Chore/merge bucket

### DIFF
--- a/packages/rnv-engine-rn/src/sdks/sdk-android/index.js
+++ b/packages/rnv-engine-rn/src/sdks/sdk-android/index.js
@@ -158,7 +158,7 @@ export const runAndroid = async (c, defaultTarget) => {
 
     await resetAdb(c);
 
-    if (target && net.isIP(target)) {
+    if (target && net.isIP(target.split(':')[0])) {
         await connectToWifiDevice(c, target);
     }
 

--- a/packages/rnv/src/core/sdkManager/deviceUtils/android.js
+++ b/packages/rnv/src/core/sdkManager/deviceUtils/android.js
@@ -450,14 +450,18 @@ const getEmulatorName = async (c, words) => {
     return emulatorName;
 };
 
-export const connectToWifiDevice = async (c, ip) => {
+export const connectToWifiDevice = async (c, target) => {
+    let connect_str = 'connect '+target;
+    if(target.split(':')[1] === null){
+        connect_str = 'connect '+target+':5555';
+    }
     const deviceResponse = await execCLI(
         c,
         CLI_ANDROID_ADB,
-        `connect ${ip}:5555`
+        connect_str
     );
     if (deviceResponse.includes('connected')) return true;
-    logError(`Failed to connect to ${ip}:5555`, false, true);
+    logError(`Failed to ${connect_str}`, false, true);
     return false;
 };
 

--- a/packages/rnv/src/core/sdkManager/deviceUtils/android.js
+++ b/packages/rnv/src/core/sdkManager/deviceUtils/android.js
@@ -451,10 +451,12 @@ const getEmulatorName = async (c, words) => {
 };
 
 export const connectToWifiDevice = async (c, target) => {
-    let connect_str = 'connect '+target;
-    if(target.split(':')[1] === null){
-        connect_str = 'connect '+target+':5555';
+    let connect_str = `connect ${target}`;
+
+    if (!target.includes(':')) {
+        connect_str = `connect ${target}:5555`;
     }
+
     const deviceResponse = await execCLI(
         c,
         CLI_ANDROID_ADB,


### PR DESCRIPTION
## Description 

Refactored adb port support

## Breaking Changes

- PRs should not introduce breaking changes to existing functionality 
- if breaking change cannot be avoided it has to be introduced in 2 phases (release cycles of 0.x.0)
    - `0.x.0` Add new functionality + add `DEPRECATED` warning to existing fuctionality
    - `0.[x+1].0` Remove deprecated functionality
    
 ## I have tested my changes on:
 
 ReNative project directly:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

New project:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

Existing Project created with previous version of renative:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
