### PR TITLE
chore(rn-electron): upgrade electron-builder version

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8247,6 +8247,310 @@ rnv run -p android
 - none
 
   
+## v0.32.0-feat-rn-electron-0 (2021-11-10)
+
+### Fixed
+
+- chore(rn-electron): upgrade electron-builder version to 22.13.1
+- fix(rn-electron): revert electron-builder command execution
+- Merge pull request #721 from pavjacko/feat/plugins_support
+- Merge branch 'develop' of github.com:pavjacko/renative into develop
+- rename macos scheme
+- fixed web path
+- Merge branch 'feat/engines-merged' into develop
+- Merge branch 'feat/engines-merged' of github.com:pavjacko/renative into feat/engines-merged
+- added missing dep, fixed new avd bin path
+- Merge pull request #696 from whenmoon/fix-navigation-from-drawer-to-home
+- Merge branch 'feat/engines-merged' of github.com:pavjacko/renative into feat/engines-merged
+- [fix] switch to engine-rn (catalyst mode) fro macos
+- 0.32.0-feat-engines-merged-16
+- chore(rn-electron): change how electron-builder command is executed
+- [fix] sanity runner
+- Merge pull request #722 from pavjacko/feat/kotlin_version
+- Merge pull request #724 from pavjacko/chore/merge_bucket
+- Merge pull request #675 from pavjacko/dependabot/npm_and_yarn/website/hosted-git-info-2.8.9
+- Merge pull request #688 from pavjacko/dependabot/npm_and_yarn/website/postcss-7.0.36
+- Merge pull request #692 from pavjacko/dependabot/npm_and_yarn/website/set-getter-0.1.1
+- Merge pull request #706 from pavjacko/dependabot/npm_and_yarn/website/path-parse-1.0.7
+- Merge pull request #710 from pavjacko/dependabot/npm_and_yarn/website/color-string-1.6.0
+- Merge pull request #711 from pavjacko/dependabot/npm_and_yarn/website/url-parse-1.5.3
+- Merge pull request #714 from pavjacko/dependabot/npm_and_yarn/website/prismjs-1.25.0
+- Merge pull request #723 from pavjacko/chore/merge_bucket
+- better readability for adb port support
+- Merge pull request #686 from AnpherZhang/develop
+- Merge pull request #684 from iMokhles/patch-1
+- Merge pull request #676 from soroushchehresa/patch-1
+- added support for kotlin version inject
+- added plugins support
+- 0.32.0-feat-engines-merged-15
+- support for macos builds
+- plugin fixes
+- [fix] index.html custom override not working
+- 0.32.0-feat-engines-merged-14
+- macos runner
+- Merge branch 'feat/engines-merged' of github.com:pavjacko/renative into feat/engines-merged
+- macos support
+- 0.32.0-feat-engines-merged-13
+- fix(AndroidTV:engine-tvos): A few more plugin sanitization fixes on tvOS engine
+- feat(engine-macos): Add deploy task to macos engine to be able to trigger build hook
+- fix(AndroidTV:engine-tvos): Plugin santization added to tvos engine as it exists on regular rn engine
+- Merge branch 'feat/engines-merged' of github.com:pavjacko/renative into feat/engines-merged
+- M1 support for electron, macos support fixes
+- [chore] 0.32.0-feat-engines-merged-12
+- [chore] update dependencies
+- add macos support for engine-rn
+- [chore] 0.32.0-feat-engines-merged-11
+- soLoader crash fix for android 11
+- fix(WebOS): Some fixes for webOS SDK and emulator detection
+- fix(RN Windows): Fix engine internals to use recently added monrepoRoot prop
+- fix(EngineNext): Fix adapter and add next.config to coreTemplateFiles
+- 0.32.0-feat-engines-merged-10
+- [feat] ability to make unsigned builds
+- 0.32.0-feat-engines-merged-9
+- [fix] avoid infinite loop if module resolution gets corrupted
+- 0.32.0-feat-engines-merged-8
+- Merge pull request #715 from pavjacko/feat/custom-mono-root
+- feat: add config prop `monoRoot`
+- Bump prismjs from 1.23.0 to 1.25.0 in /website
+- 0.32.0-feat-engines-merged-7
+- skip rn packaging id bundleAssets is false
+- 0.32.0-feat-engines-merged-6
+- [fix] allow auto restart if --ci
+- 0.32.0-feat-engines-merged-5
+- Merge branch 'feat/engines-merged' of https://github.com/pavjacko/renative into feat/engines-merged
+- chore: remove extraNodeModules spread in metro config adapter
+- chore: bump next-transpile-modules
+- chore: bump react-native-vector-icons
+- activate aab in build phases, ignore for run
+- [fix] run on device
+- 0.32.0-feat-engines-merged-4
+- refactor(RN Windows): Remove newer react native cli dependency, because it was needed for rn 0.64
+- fix(RN Windows): Fix inccorect property names in renative config
+- 0.32.0-feat-engines-merged-3
+- fix(RN Windows): Fixes needed for bootstrapping new projects and using RN Windows in them
+- 0.32.0-feat-engines-merged-2
+- feat(Xbox): Added Xbox as a platform that runs on RN Windows engine
+- added @babel/helper-builder-react-jsx-experimental dep
+- Merge branch 'feat/engines-merged' of https://github.com/pavjacko/renative into feat/engines-merged
+- 0.32.0-feat-engines-merged-1
+- Merge branch 'feat/include_asdk_env_locations' into feat/engines-merged
+- fix(Windows): Add windows engine as a dev dependency to app package
+- Merge branch 'feat/engines-merged' of github.com:pavjacko/renative into feat/engines-merged
+- add helper builder dep
+- fix(Windows): Default app icon assets not getting picked up issue fix
+- fix(Windows): Unify RN Windows engine version with other packages versions
+- Merge branch 'feat/react-native-windows' into feat/engines-merged
+- 0.32.0-feat-asdk-7
+- fix(Xbox): Add Xbox application size and focus navigation enablement fix for apps using RN Windows engine
+- Merge branch 'feat/react-native-windows' into feat/engines-merged
+- 0.32.0-feat-rnwin-5
+- fix(platformAssets): Platform assets not getting copied over to the project, because default ones exist fix
+- 0.32.0-feat-asdk-6
+- 0.32.0-feat-asdk-5
+- 0.32.0-feat-rnwin-4
+- fix(Logs): Remove console.logs accidentally added by the previous commit
+- improvement(Docs): Updated documentation for configuration properties accepted by RN Windows
+- fix(clean): Fix rnv clean cache command on Windows machines
+- 0.32.0-feat-asdk-4
+- 0.32.0-feat-asdk-3
+- merge with engines
+- 0.32.0-feat-asdk-3
+- 0.32.0-feat-rnwin-3
+- Merge branch 'feat/react-native-windows' of github.com:pavjacko/renative into feat/react-native-windows
+- fix(RN Windows): Fix namespace being assigned a title with spaces in between
+- 0.32.0-feat-rnwin-2
+- fix(RN Windows): Fix existing metro config in project getting overriden
+- fix(RN Windows): Fix overrides of the default project files
+- 0.32.0-feat-rnwin-1
+- fix(RN Windows): Fix documentation of RN Windows engine
+- 0.32.0-feat-rnwin-0
+- fix(RN Windows): Fixes for RN Windows engine copied over from engines merged branch
+- chore (hello-world template): upgraded react-navigation `core`and `native` versions to match ones required by plugin templates
+- fix (tvos: rnv templates buildSchemes): remove redundant property `scheme` from `releae` buildScheme
+- chore (rn-macos engine): revert `inlineRequires` property to `false`in metro config
+- fix(RN Windows): Fixes needed for RN Windows engine to run in engines merged branch
+- 0.32.0-feat-asdk-2
+- Merge branch 'feat/react-native-windows' into feat/engines-merged
+- refactor(RN): Downgrade react native version to the maximum supported one by the tvos engine
+- Merge pull request #690 from kasinskas/feat/lightning-engine
+- Merge branch 'feat/engines-merged' of https://github.com/pavjacko/renative into feat/lightning-engine
+- update dep locks
+- Merge branch 'feat/include_asdk_env_locations' into feat/merges
+- Merge branch 'feat/react-native-windows' into feat/merges
+- Merge branch 'feat/engine-macos' into feat/merges
+- Merge branch 'feat/engine-tvos' into feat/merges
+- Merge branch 'fix/windows-android-builds' into feat/merges
+- Merge branch 'fix/android-bundler' into feat/merges
+- Merge branch 'feat/appDelegate-extensions' into feat/merges
+- Merge branch 'fix/resolve-monorepo-assets-paths' into feat/merges
+- Bump url-parse from 1.5.1 to 1.5.3 in /website
+- Bump color-string from 1.5.4 to 1.6.0 in /website
+- expose fs api
+- fix(Export): Fix some issues with exporting a package
+- 0.32.0-feat-asdk-1
+- fixed conflicts
+- 0.32.0-feat-asdk-0
+- fixed typo
+- added common env variable locations for Android SDK
+- improve(Export): Add install and sign scripts as part of of export function for now
+- feat(Windows Export): Added export command logic for RN Windows engine
+- Bump path-parse from 1.0.6 to 1.0.7 in /website
+- feat(App Title): getAppTitle from renative is now used to set the title of the application
+- 0.32.0-feat-rnmacos-8
+- feat(App Icons): ReNative icons added for RN Windows applications as the default icons
+- chore (macos engines): make `rn-electron` default macos engine and change the engine to `rn-macos` only for hello-world app
+- fix (rn-macos, rn-electron engines): make it possible to run macos platform on both engines
+- chore (renative): add constants which determines current engine
+- fix(Icons): Fixed linking for icon files
+- fix (rn-macos engine): remove `ios` extension to fix app crashing on launch
+- refactor (rn-macos engine): change `overview` field for the engine
+- fix(Plugins): Update navigation and reanimated plugins to versions, which support react native windows
+- chore (rn-macos engine): added more extensions for the macos platform
+- improvement (rn-tvos engine): add default metro.config.rnt.js file for tvOS platform and additional constant `RNT_CLI_CONFIG_NAME`
+- refactor (rn-macos engine): fix a comment
+- chore (plugin overrides): add comments to react-native-community override to easily find the override
+- fix(Windows Builds): Fixed renative build cli function for Windows
+- 0.32.0-feat-tvos-4
+- fix(Reanimated plugin): Bump up version for the plugin as it causes a crash within react navigation
+- fix(Windows Release): Cleaned up cache clearing command
+- fix(Windows Release): Added additional cache clearing which seems to have fixed release builds via CLI
+- fix(versions): Revert version upgrade in order to make this a viable PR for merge
+- fix (rn-tvos engine, androidtv/firetv): fix app deployment in release mode
+- 0.32.0-feat-winbuilds-1
+- Merge branch 'fix/windows-android-builds' of https://github.com/pavjacko/renative into fix/windows-android-builds
+- fix(Windows Workspace): Fix issues with workspace config on Windows caused by my previous commit
+- fix (rn-tvos engine, tvOS: @react-native-community overrides): remove extra parameter from a function call to fix running an app on tvOS simulator
+- 0.32.0-feat-winbuilds-0
+- fix (rn-tvos engine, tvOS): fix tvos app deployment to devices
+- fix(Windows): Fixing android release builds execution on windows
+- refactor (rn-tvos engine): rename xcode workspace file name to correct one
+- fix (rn-tvos engine): fix the issue where tvos simulator and app wouldn't open when running in release mode
+- refactor (rn-engine tvos): remove unused files
+- fix(Windows Build): Fixing debug builds via CLI
+- 0.32.0-feat-tvos-3
+- 0.32.0-feat-tvos.2
+- chore (buildHooks): add rn-tvos engine package.json to `updateVersions` build hook
+- chore (rnv templates): add "INTERNET" to `includedPermissions` to fix android/androidtv connection to bundler
+- improvement(Windows Clean): Added temporary files cleaning to the build process
+- 0.32.0-feat-rnmacos-7
+- improvement (rn-macos engine): add default metro.config.rnm.js file for macOS platform and additional constant `RNM_CLI_CONFIG_NAME`
+- chore (react-native-reanimated): downgrade plugin version and add temp overrides for macOS platform to work properly
+- fix(Windows Run): Fixing -r flag run process hang on Windows
+- 0.32.0-feat-rnmacos-6
+- 0.32.0-feat-rnmacos-5
+- chore (rn-macos engine): add few more default properties to entitlements
+- 0.32.0-feat-rnmacos-4
+- fix (rn-macos engine): fix code signing entitlements and add default properties to entitlements.plist
+- fix (template-hello-world: macOS): removed `macos` specific file
+- improvements (rn-macos engine): add missing default  app icons to `assets`
+- fix (rn-macos engine): change engine `projectDirName` from `project` to empty string so application assets would be copied properly
+- chore (rn-macos engine): add `macos`to missing engines config
+- 0.32.0-feat-rnmacos-3
+- fix (rn-macos engine): fix missed things for specific metro config
+- 0.32.0-feat-rnmacos-2
+- refactor (rn-macos engine): remove unused file
+- chore (rn-macos engine): add `rnm` specific metro config
+- fix (rn-macos engine: `package` script): change platform from `ios`to `macos`when packaging
+- fix (rn-template-hello-world, macOS: app): add a check to not render a CastButton for `desktop`platforms
+- chore (app/rnv/hello-world): upgrade `react-navigation/stack`, `react-navigation/native`, `react-native-reanimated` and `react-native-safe-area-context` versions for macOS to work properly
+- fix (rn-macos engine): dynamic app title
+- feat (rn-macos): inject dynamic application title to podfile and xcode project configuration
+- feat (rn-macos engine): add storyboard parser so it would be possible to inject dynamic application title
+- fix(Windows Navigation): Fix issues with react navigation
+- 0.32.0-feat-rnmacos-1
+- chore (builhooks): add rn-macos engine to `updateVersions` hook
+- fix(Windows Metro): Fix bundle placing
+- 0.32.0-feat-rnmacos-0
+- fix (rn-macos engine): add `teamID` to `exportOptions`
+- fix (rn-macos engine): AppDelegate script for bundle
+- improvement (rn-macos engine): add `export` command and make possible to run app in release mode via cli
+- fix(Windows Metro): Fix the issue with packager running in a separate window
+- 0.32.0-feat-tvos.1
+- 0.32.0-feat-tvos.0
+- 0.32.0-feat-tvos.0
+- set default engine as engine-rn-tvos for native tvs
+- Add android tv and firetv to tvos engine
+- fix android based platforms connection to bundler, add dedicated metro config for tvos engine
+- [fix] total plugin count
+- improvement (rn-macos engine): add `package` and `build` rnv commands
+- fix(Windows Metro): Fix custom server port config via renative for app to run
+- refactor (rn-macos engine): clean up some code and rename some files
+- chore (rn-macos engine): add missing macos engine package to both `blank`and `hello-world`templates renative config
+- improvement (rn-macos engine: AppDelegate): dynamic bundle url
+- fix (rn-macos engine: xcode project configuration): remove unused children from frameworks
+- improve(Run): Updated Windows SDK to allow for more configuration via renative.json
+- fix(Run): Windows application launches and runs using rnv
+- fix (rn-macos engine): fix fonts
+- 0.32.0-feat-lightning-1
+- fix(Run): Initial issues fixing for metro, that prevent bundler from starting
+- [feat] add missing includedPlugins warning
+- improvement (renative package): add Api constant for `engine-rn-macos`
+- improvement (rn-macos engine): remove ios/tvos related stuff from xcodeParser, remove unecessary property from template apps renative.json
+- improvement (rn-macos engine): remove unused swiftParser
+- fix (rn-macos engine): fix runtime errors when running the app by changing the platform to correct one in bundle url
+- [fix] detox fixes
+- fix(Run): Windows builds the project successfully with rnv
+- chore (rn-macos engine): removed some ios/tvos platforms related configuration from xcode project config
+- improvement (rn-macos engine): add `run` command
+- chore(Lightning): bump lightning cli
+- improvement (rn-macos engine): add `start` command
+- fix(Configure): Don't override the metro config by default
+- chore: remove ios target from rn-macos engine xcode project
+- feat(Configure): Initial version of configure command for RN WIndows Engine
+- feat (macos engine): initial engine setup, `configure` command
+- temp(RN Windows): Rewriting configure from RN Windows CLI
+- improvement(Configure): Working on Windows configure task
+- improvement(Windows Engine): Copied the generated logic into templates and prepared for initial setup
+- remove some unneded cli overrides
+- bring back removed metro config
+- add missing tasks to engine-rn-tvos
+- remove tvos from engine-rn
+- tvos as separate engine
+- fix: navigating home from navigation drawer
+- feat(RNW): Added packages needed for react native windows
+- fix(Lightning): required build files not always being generated
+- feat: enable hosted param for lightning and run the app to simulator
+- feat: package lightning apps using rnv build
+- chore: dont hoist lightning cli dep
+- fix: change lightning esbuild override targets, since previous didnt match
+- feat(Lightning): add configure task
+- chore: add lng engine templates
+- fix(iOS:RN Engine): After version bump up for react-native iOS build failing fix
+- improvement(RN Engine tvOS): Added tvOS engine to templates and other places where other engines are specified
+- Bump set-getter from 0.1.0 to 0.1.1 in /website
+- fix(Lightning): override es5 configs to support extensions and different entry files
+- improvement: add current engine to env variables
+- feat(Lightning): allow specifying build target in renative config
+- improvement(Lightning): override entry file location to match other platforms
+- improvement(Lightning): use platform ports
+- chore: add lightning engine references
+- improvement(Lightning): add build task
+- feat(Lightning): add webos to lightning engine
+- feat(Lightning): resolve .lng extensions
+- feat(Lightning): override hardcoded served build folder path in lng package
+- fix(Lightning): enable relative path for build folder
+- chore: bump lightning sdk package and add cli
+- Bump postcss from 7.0.35 to 7.0.36 in /website
+- feat(CarPlay): Add CarPlay plugin to the list of possible plugins
+- feat(AppDelegate): Added extensions for application and methods needed for CarPlay support
+- [ReNative][Android][Debug-RunAndroid] support rnv run -p android -t 127.0.0.1:7555
+- [fix] resolve paths in monorepo projects
+- engine tvos wip
+- [fix] Xcode 12.5 fix edge cases with RN Pod override
+- Update renative.json
+- fixed web and webtv debug enviroment
+- Fix FireTV documentation link
+- Bump hosted-git-info from 2.8.8 to 2.8.9 in /website
+
+### Added Features
+
+- none
+
+### Breaking Changes
+
+- none
+
+  
 ## v0.32.0-feat-rnmacos-0 (2021-7-22)
 
 ### Fixed

--- a/docs/changelog/0.32.0-feat-rn-electron-0.md
+++ b/docs/changelog/0.32.0-feat-rn-electron-0.md
@@ -1,0 +1,304 @@
+## v0.32.0-feat-rn-electron-0 (2021-11-10)
+
+### Fixed
+
+- chore(rn-electron): upgrade electron-builder version to 22.13.1
+- fix(rn-electron): revert electron-builder command execution
+- Merge pull request #721 from pavjacko/feat/plugins_support
+- Merge branch 'develop' of github.com:pavjacko/renative into develop
+- rename macos scheme
+- fixed web path
+- Merge branch 'feat/engines-merged' into develop
+- Merge branch 'feat/engines-merged' of github.com:pavjacko/renative into feat/engines-merged
+- added missing dep, fixed new avd bin path
+- Merge pull request #696 from whenmoon/fix-navigation-from-drawer-to-home
+- Merge branch 'feat/engines-merged' of github.com:pavjacko/renative into feat/engines-merged
+- [fix] switch to engine-rn (catalyst mode) fro macos
+- 0.32.0-feat-engines-merged-16
+- chore(rn-electron): change how electron-builder command is executed
+- [fix] sanity runner
+- Merge pull request #722 from pavjacko/feat/kotlin_version
+- Merge pull request #724 from pavjacko/chore/merge_bucket
+- Merge pull request #675 from pavjacko/dependabot/npm_and_yarn/website/hosted-git-info-2.8.9
+- Merge pull request #688 from pavjacko/dependabot/npm_and_yarn/website/postcss-7.0.36
+- Merge pull request #692 from pavjacko/dependabot/npm_and_yarn/website/set-getter-0.1.1
+- Merge pull request #706 from pavjacko/dependabot/npm_and_yarn/website/path-parse-1.0.7
+- Merge pull request #710 from pavjacko/dependabot/npm_and_yarn/website/color-string-1.6.0
+- Merge pull request #711 from pavjacko/dependabot/npm_and_yarn/website/url-parse-1.5.3
+- Merge pull request #714 from pavjacko/dependabot/npm_and_yarn/website/prismjs-1.25.0
+- Merge pull request #723 from pavjacko/chore/merge_bucket
+- better readability for adb port support
+- Merge pull request #686 from AnpherZhang/develop
+- Merge pull request #684 from iMokhles/patch-1
+- Merge pull request #676 from soroushchehresa/patch-1
+- added support for kotlin version inject
+- added plugins support
+- 0.32.0-feat-engines-merged-15
+- support for macos builds
+- plugin fixes
+- [fix] index.html custom override not working
+- 0.32.0-feat-engines-merged-14
+- macos runner
+- Merge branch 'feat/engines-merged' of github.com:pavjacko/renative into feat/engines-merged
+- macos support
+- 0.32.0-feat-engines-merged-13
+- fix(AndroidTV:engine-tvos): A few more plugin sanitization fixes on tvOS engine
+- feat(engine-macos): Add deploy task to macos engine to be able to trigger build hook
+- fix(AndroidTV:engine-tvos): Plugin santization added to tvos engine as it exists on regular rn engine
+- Merge branch 'feat/engines-merged' of github.com:pavjacko/renative into feat/engines-merged
+- M1 support for electron, macos support fixes
+- [chore] 0.32.0-feat-engines-merged-12
+- [chore] update dependencies
+- add macos support for engine-rn
+- [chore] 0.32.0-feat-engines-merged-11
+- soLoader crash fix for android 11
+- fix(WebOS): Some fixes for webOS SDK and emulator detection
+- fix(RN Windows): Fix engine internals to use recently added monrepoRoot prop
+- fix(EngineNext): Fix adapter and add next.config to coreTemplateFiles
+- 0.32.0-feat-engines-merged-10
+- [feat] ability to make unsigned builds
+- 0.32.0-feat-engines-merged-9
+- [fix] avoid infinite loop if module resolution gets corrupted
+- 0.32.0-feat-engines-merged-8
+- Merge pull request #715 from pavjacko/feat/custom-mono-root
+- feat: add config prop `monoRoot`
+- Bump prismjs from 1.23.0 to 1.25.0 in /website
+- 0.32.0-feat-engines-merged-7
+- skip rn packaging id bundleAssets is false
+- 0.32.0-feat-engines-merged-6
+- [fix] allow auto restart if --ci
+- 0.32.0-feat-engines-merged-5
+- Merge branch 'feat/engines-merged' of https://github.com/pavjacko/renative into feat/engines-merged
+- chore: remove extraNodeModules spread in metro config adapter
+- chore: bump next-transpile-modules
+- chore: bump react-native-vector-icons
+- activate aab in build phases, ignore for run
+- [fix] run on device
+- 0.32.0-feat-engines-merged-4
+- refactor(RN Windows): Remove newer react native cli dependency, because it was needed for rn 0.64
+- fix(RN Windows): Fix inccorect property names in renative config
+- 0.32.0-feat-engines-merged-3
+- fix(RN Windows): Fixes needed for bootstrapping new projects and using RN Windows in them
+- 0.32.0-feat-engines-merged-2
+- feat(Xbox): Added Xbox as a platform that runs on RN Windows engine
+- added @babel/helper-builder-react-jsx-experimental dep
+- Merge branch 'feat/engines-merged' of https://github.com/pavjacko/renative into feat/engines-merged
+- 0.32.0-feat-engines-merged-1
+- Merge branch 'feat/include_asdk_env_locations' into feat/engines-merged
+- fix(Windows): Add windows engine as a dev dependency to app package
+- Merge branch 'feat/engines-merged' of github.com:pavjacko/renative into feat/engines-merged
+- add helper builder dep
+- fix(Windows): Default app icon assets not getting picked up issue fix
+- fix(Windows): Unify RN Windows engine version with other packages versions
+- Merge branch 'feat/react-native-windows' into feat/engines-merged
+- 0.32.0-feat-asdk-7
+- fix(Xbox): Add Xbox application size and focus navigation enablement fix for apps using RN Windows engine
+- Merge branch 'feat/react-native-windows' into feat/engines-merged
+- 0.32.0-feat-rnwin-5
+- fix(platformAssets): Platform assets not getting copied over to the project, because default ones exist fix
+- 0.32.0-feat-asdk-6
+- 0.32.0-feat-asdk-5
+- 0.32.0-feat-rnwin-4
+- fix(Logs): Remove console.logs accidentally added by the previous commit
+- improvement(Docs): Updated documentation for configuration properties accepted by RN Windows
+- fix(clean): Fix rnv clean cache command on Windows machines
+- 0.32.0-feat-asdk-4
+- 0.32.0-feat-asdk-3
+- merge with engines
+- 0.32.0-feat-asdk-3
+- 0.32.0-feat-rnwin-3
+- Merge branch 'feat/react-native-windows' of github.com:pavjacko/renative into feat/react-native-windows
+- fix(RN Windows): Fix namespace being assigned a title with spaces in between
+- 0.32.0-feat-rnwin-2
+- fix(RN Windows): Fix existing metro config in project getting overriden
+- fix(RN Windows): Fix overrides of the default project files
+- 0.32.0-feat-rnwin-1
+- fix(RN Windows): Fix documentation of RN Windows engine
+- 0.32.0-feat-rnwin-0
+- fix(RN Windows): Fixes for RN Windows engine copied over from engines merged branch
+- chore (hello-world template): upgraded react-navigation `core`and `native` versions to match ones required by plugin templates
+- fix (tvos: rnv templates buildSchemes): remove redundant property `scheme` from `releae` buildScheme
+- chore (rn-macos engine): revert `inlineRequires` property to `false`in metro config
+- fix(RN Windows): Fixes needed for RN Windows engine to run in engines merged branch
+- 0.32.0-feat-asdk-2
+- Merge branch 'feat/react-native-windows' into feat/engines-merged
+- refactor(RN): Downgrade react native version to the maximum supported one by the tvos engine
+- Merge pull request #690 from kasinskas/feat/lightning-engine
+- Merge branch 'feat/engines-merged' of https://github.com/pavjacko/renative into feat/lightning-engine
+- update dep locks
+- Merge branch 'feat/include_asdk_env_locations' into feat/merges
+- Merge branch 'feat/react-native-windows' into feat/merges
+- Merge branch 'feat/engine-macos' into feat/merges
+- Merge branch 'feat/engine-tvos' into feat/merges
+- Merge branch 'fix/windows-android-builds' into feat/merges
+- Merge branch 'fix/android-bundler' into feat/merges
+- Merge branch 'feat/appDelegate-extensions' into feat/merges
+- Merge branch 'fix/resolve-monorepo-assets-paths' into feat/merges
+- Bump url-parse from 1.5.1 to 1.5.3 in /website
+- Bump color-string from 1.5.4 to 1.6.0 in /website
+- expose fs api
+- fix(Export): Fix some issues with exporting a package
+- 0.32.0-feat-asdk-1
+- fixed conflicts
+- 0.32.0-feat-asdk-0
+- fixed typo
+- added common env variable locations for Android SDK
+- improve(Export): Add install and sign scripts as part of of export function for now
+- feat(Windows Export): Added export command logic for RN Windows engine
+- Bump path-parse from 1.0.6 to 1.0.7 in /website
+- feat(App Title): getAppTitle from renative is now used to set the title of the application
+- 0.32.0-feat-rnmacos-8
+- feat(App Icons): ReNative icons added for RN Windows applications as the default icons
+- chore (macos engines): make `rn-electron` default macos engine and change the engine to `rn-macos` only for hello-world app
+- fix (rn-macos, rn-electron engines): make it possible to run macos platform on both engines
+- chore (renative): add constants which determines current engine
+- fix(Icons): Fixed linking for icon files
+- fix (rn-macos engine): remove `ios` extension to fix app crashing on launch
+- refactor (rn-macos engine): change `overview` field for the engine
+- fix(Plugins): Update navigation and reanimated plugins to versions, which support react native windows
+- chore (rn-macos engine): added more extensions for the macos platform
+- improvement (rn-tvos engine): add default metro.config.rnt.js file for tvOS platform and additional constant `RNT_CLI_CONFIG_NAME`
+- refactor (rn-macos engine): fix a comment
+- chore (plugin overrides): add comments to react-native-community override to easily find the override
+- fix(Windows Builds): Fixed renative build cli function for Windows
+- 0.32.0-feat-tvos-4
+- fix(Reanimated plugin): Bump up version for the plugin as it causes a crash within react navigation
+- fix(Windows Release): Cleaned up cache clearing command
+- fix(Windows Release): Added additional cache clearing which seems to have fixed release builds via CLI
+- fix(versions): Revert version upgrade in order to make this a viable PR for merge
+- fix (rn-tvos engine, androidtv/firetv): fix app deployment in release mode
+- 0.32.0-feat-winbuilds-1
+- Merge branch 'fix/windows-android-builds' of https://github.com/pavjacko/renative into fix/windows-android-builds
+- fix(Windows Workspace): Fix issues with workspace config on Windows caused by my previous commit
+- fix (rn-tvos engine, tvOS: @react-native-community overrides): remove extra parameter from a function call to fix running an app on tvOS simulator
+- 0.32.0-feat-winbuilds-0
+- fix (rn-tvos engine, tvOS): fix tvos app deployment to devices
+- fix(Windows): Fixing android release builds execution on windows
+- refactor (rn-tvos engine): rename xcode workspace file name to correct one
+- fix (rn-tvos engine): fix the issue where tvos simulator and app wouldn't open when running in release mode
+- refactor (rn-engine tvos): remove unused files
+- fix(Windows Build): Fixing debug builds via CLI
+- 0.32.0-feat-tvos-3
+- 0.32.0-feat-tvos.2
+- chore (buildHooks): add rn-tvos engine package.json to `updateVersions` build hook
+- chore (rnv templates): add "INTERNET" to `includedPermissions` to fix android/androidtv connection to bundler
+- improvement(Windows Clean): Added temporary files cleaning to the build process
+- 0.32.0-feat-rnmacos-7
+- improvement (rn-macos engine): add default metro.config.rnm.js file for macOS platform and additional constant `RNM_CLI_CONFIG_NAME`
+- chore (react-native-reanimated): downgrade plugin version and add temp overrides for macOS platform to work properly
+- fix(Windows Run): Fixing -r flag run process hang on Windows
+- 0.32.0-feat-rnmacos-6
+- 0.32.0-feat-rnmacos-5
+- chore (rn-macos engine): add few more default properties to entitlements
+- 0.32.0-feat-rnmacos-4
+- fix (rn-macos engine): fix code signing entitlements and add default properties to entitlements.plist
+- fix (template-hello-world: macOS): removed `macos` specific file
+- improvements (rn-macos engine): add missing default  app icons to `assets`
+- fix (rn-macos engine): change engine `projectDirName` from `project` to empty string so application assets would be copied properly
+- chore (rn-macos engine): add `macos`to missing engines config
+- 0.32.0-feat-rnmacos-3
+- fix (rn-macos engine): fix missed things for specific metro config
+- 0.32.0-feat-rnmacos-2
+- refactor (rn-macos engine): remove unused file
+- chore (rn-macos engine): add `rnm` specific metro config
+- fix (rn-macos engine: `package` script): change platform from `ios`to `macos`when packaging
+- fix (rn-template-hello-world, macOS: app): add a check to not render a CastButton for `desktop`platforms
+- chore (app/rnv/hello-world): upgrade `react-navigation/stack`, `react-navigation/native`, `react-native-reanimated` and `react-native-safe-area-context` versions for macOS to work properly
+- fix (rn-macos engine): dynamic app title
+- feat (rn-macos): inject dynamic application title to podfile and xcode project configuration
+- feat (rn-macos engine): add storyboard parser so it would be possible to inject dynamic application title
+- fix(Windows Navigation): Fix issues with react navigation
+- 0.32.0-feat-rnmacos-1
+- chore (builhooks): add rn-macos engine to `updateVersions` hook
+- fix(Windows Metro): Fix bundle placing
+- 0.32.0-feat-rnmacos-0
+- fix (rn-macos engine): add `teamID` to `exportOptions`
+- fix (rn-macos engine): AppDelegate script for bundle
+- improvement (rn-macos engine): add `export` command and make possible to run app in release mode via cli
+- fix(Windows Metro): Fix the issue with packager running in a separate window
+- 0.32.0-feat-tvos.1
+- 0.32.0-feat-tvos.0
+- 0.32.0-feat-tvos.0
+- set default engine as engine-rn-tvos for native tvs
+- Add android tv and firetv to tvos engine
+- fix android based platforms connection to bundler, add dedicated metro config for tvos engine
+- [fix] total plugin count
+- improvement (rn-macos engine): add `package` and `build` rnv commands
+- fix(Windows Metro): Fix custom server port config via renative for app to run
+- refactor (rn-macos engine): clean up some code and rename some files
+- chore (rn-macos engine): add missing macos engine package to both `blank`and `hello-world`templates renative config
+- improvement (rn-macos engine: AppDelegate): dynamic bundle url
+- fix (rn-macos engine: xcode project configuration): remove unused children from frameworks
+- improve(Run): Updated Windows SDK to allow for more configuration via renative.json
+- fix(Run): Windows application launches and runs using rnv
+- fix (rn-macos engine): fix fonts
+- 0.32.0-feat-lightning-1
+- fix(Run): Initial issues fixing for metro, that prevent bundler from starting
+- [feat] add missing includedPlugins warning
+- improvement (renative package): add Api constant for `engine-rn-macos`
+- improvement (rn-macos engine): remove ios/tvos related stuff from xcodeParser, remove unecessary property from template apps renative.json
+- improvement (rn-macos engine): remove unused swiftParser
+- fix (rn-macos engine): fix runtime errors when running the app by changing the platform to correct one in bundle url
+- [fix] detox fixes
+- fix(Run): Windows builds the project successfully with rnv
+- chore (rn-macos engine): removed some ios/tvos platforms related configuration from xcode project config
+- improvement (rn-macos engine): add `run` command
+- chore(Lightning): bump lightning cli
+- improvement (rn-macos engine): add `start` command
+- fix(Configure): Don't override the metro config by default
+- chore: remove ios target from rn-macos engine xcode project
+- feat(Configure): Initial version of configure command for RN WIndows Engine
+- feat (macos engine): initial engine setup, `configure` command
+- temp(RN Windows): Rewriting configure from RN Windows CLI
+- improvement(Configure): Working on Windows configure task
+- improvement(Windows Engine): Copied the generated logic into templates and prepared for initial setup
+- remove some unneded cli overrides
+- bring back removed metro config
+- add missing tasks to engine-rn-tvos
+- remove tvos from engine-rn
+- tvos as separate engine
+- fix: navigating home from navigation drawer
+- feat(RNW): Added packages needed for react native windows
+- fix(Lightning): required build files not always being generated
+- feat: enable hosted param for lightning and run the app to simulator
+- feat: package lightning apps using rnv build
+- chore: dont hoist lightning cli dep
+- fix: change lightning esbuild override targets, since previous didnt match
+- feat(Lightning): add configure task
+- chore: add lng engine templates
+- fix(iOS:RN Engine): After version bump up for react-native iOS build failing fix
+- improvement(RN Engine tvOS): Added tvOS engine to templates and other places where other engines are specified
+- Bump set-getter from 0.1.0 to 0.1.1 in /website
+- fix(Lightning): override es5 configs to support extensions and different entry files
+- improvement: add current engine to env variables
+- feat(Lightning): allow specifying build target in renative config
+- improvement(Lightning): override entry file location to match other platforms
+- improvement(Lightning): use platform ports
+- chore: add lightning engine references
+- improvement(Lightning): add build task
+- feat(Lightning): add webos to lightning engine
+- feat(Lightning): resolve .lng extensions
+- feat(Lightning): override hardcoded served build folder path in lng package
+- fix(Lightning): enable relative path for build folder
+- chore: bump lightning sdk package and add cli
+- Bump postcss from 7.0.35 to 7.0.36 in /website
+- feat(CarPlay): Add CarPlay plugin to the list of possible plugins
+- feat(AppDelegate): Added extensions for application and methods needed for CarPlay support
+- [ReNative][Android][Debug-RunAndroid] support rnv run -p android -t 127.0.0.1:7555
+- [fix] resolve paths in monorepo projects
+- engine tvos wip
+- [fix] Xcode 12.5 fix edge cases with RN Pod override
+- Update renative.json
+- fixed web and webtv debug enviroment
+- Fix FireTV documentation link
+- Bump hosted-git-info from 2.8.8 to 2.8.9 in /website
+
+### Added Features
+
+- none
+
+### Breaking Changes
+
+- none
+
+  

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -2906,7 +2906,7 @@ rnv plugin add recyclerlistview
 ## renative
 
 
-Version: `0.32.0-feat-engines-merged-16`
+Version: `0.32.0-feat-rn-electron-0`
 
 Platforms: `ios`,`android`,`firetv`,`androidtv`,`androidwear`,`web`,`webtv`,`tizen`,`tizenmobile`,`tvos`,`webos`,`macos`,`windows`,`tizenwatch`,`kaios`,`firefoxos`,`firefoxtv`,`chromecast`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renative-wrapper",
-  "version": "0.32.0-feat-engines-merged-16",
+  "version": "0.32.0-feat-rn-electron-0",
   "currentRelease": "0.31",
   "description": "🚀🚀🚀 Build universal cross-platform apps with React Native. Includes latest `iOS`, `tvOS`, `Android`, `Android TV`, `Fire TV`, `Android Wear`, `Web`, `Tizen TV`, `Tizen Watch`, `Tizen Mobile`, `LG webOS`, `macOS/OSX`, `Windows`, `KaiOS`, `FirefoxOS`, `Firefox TV` and `Chromecast` platforms",
   "keywords": [

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "renative-app",
-    "version": "0.32.0-feat-engines-merged-16",
+    "version": "0.32.0-feat-rn-electron-0",
     "description": "🚀🚀🚀 Build universal cross-platform apps with React Native. Includes latest `iOS`, `tvOS`, `Android`, `Android TV`, `FireTV`, `Android Wear`, `Web`, `Tizen TV`, `Tizen Watch`, `Tizen Mobile`, `LG webOS`, `macOS/OSX`, `Windows`, `KaiOS`, `FirefoxOS` and `Firefox TV` platforms",
     "homepage": "https://github.com/pavjacko/renative#readme",
     "bugs": {

--- a/packages/renative-template-blank/package.json
+++ b/packages/renative-template-blank/package.json
@@ -1,6 +1,6 @@
 {
     "name": "renative-template-blank",
-    "version": "0.32.0-feat-engines-merged-16",
+    "version": "0.32.0-feat-rn-electron-0",
     "description": "🚧 Blank Template for ReNative (https://www.npmjs.com/package/renative). Supports `iOS`, `tvOS`, `Android`, `Android TV`, `FireTV`, `Android Wear`, `Web`, `Tizen TV`, `Tizen Watch`, `LG webOS`, `macOS/OSX`, `Windows`, `KaiOS`, `FirefoxOS`, `Firefox TV`",
     "keywords": [
         "android tv",

--- a/packages/renative-template-hello-world/package.json
+++ b/packages/renative-template-hello-world/package.json
@@ -1,6 +1,6 @@
 {
     "name": "renative-template-hello-world",
-    "version": "0.32.0-feat-engines-merged-16",
+    "version": "0.32.0-feat-rn-electron-0",
     "description": "🚧 Hello World Template for ReNative (https://www.npmjs.com/package/renative). Supports `iOS`, `tvOS`, `Android`, `Android TV`, `FireTV`, `Android Wear`, `Web`, `Tizen TV`, `Tizen Watch`, `LG webOS`, `macOS/OSX`, `Windows`, `KaiOS`, `FirefoxOS`, `Firefox TV`",
     "keywords": [
         "android tv",

--- a/packages/renative-template-kitchen-sink/package.json
+++ b/packages/renative-template-kitchen-sink/package.json
@@ -1,6 +1,6 @@
 {
     "name": "renative-template-kitchen-sink",
-    "version": "0.32.0-feat-engines-merged-16",
+    "version": "0.32.0-feat-rn-electron-0",
     "description": "🚀🚀🚀 Build universal cross-platform apps with React Native. Includes latest `iOS`, `tvOS`, `Android`, `Android TV`, `FireTV`, `Android Wear`, `Web`, `Tizen TV`, `Tizen Watch`, `LG webOS`, `macOS/OSX`, `Windows`, `KaiOS`, `FirefoxOS` and `Firefox TV` platforms",
     "keywords": [
         "android tv",

--- a/packages/renative/README.md
+++ b/packages/renative/README.md
@@ -409,7 +409,7 @@ More in-depth explanation how ReNative internals work
 
 `rnv run -p firetv`
 
-[Documentation for FireTV Platform](https://renative.org/docs/platform-firetv)
+[Documentation for FireTV Platform](https://renative.org/docs/next/platforms/firetv)
 
 ---
 

--- a/packages/renative/package.json
+++ b/packages/renative/package.json
@@ -1,6 +1,6 @@
 {
     "name": "renative",
-    "version": "0.32.0-feat-engines-merged-16",
+    "version": "0.32.0-feat-rn-electron-0",
     "description": "🚀🚀🚀 Build universal cross-platform apps with React Native. Includes latest `iOS`, `tvOS`, `Android`, `Android TV`, `FireTV`, `Android Wear`, `Web`, `Tizen TV`, `Tizen Watch`, `LG webOS`, `macOS/OSX`, `Windows`, `KaiOS`, `FirefoxOS` and `Firefox TV` platforms",
     "keywords": [
         "android tv",

--- a/packages/rnv-engine-lightning/package.json
+++ b/packages/rnv-engine-lightning/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnv/engine-lightning",
-    "version": "0.32.0-feat-engines-merged-16",
+    "version": "0.32.0-feat-rn-electron-0",
     "description": "ReNative Engine to build lightning based apps.",
     "keywords": [
         "lightning"

--- a/packages/rnv-engine-rn-electron/package.json
+++ b/packages/rnv-engine-rn-electron/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnv/engine-rn-electron",
-    "version": "0.32.0-feat-engines-merged-16",
+    "version": "0.32.0-feat-rn-electron-0",
     "description": "ReNative Engine to build electron based platforms with react native support.",
     "keywords": [
         "electron",

--- a/packages/rnv-engine-rn-electron/package.json
+++ b/packages/rnv-engine-rn-electron/package.json
@@ -28,7 +28,7 @@
     "dependencies": {
         "babel-loader": "8.0.5",
         "electron": "11.0.0",
-        "electron-builder": "22.8.1",
+        "electron-builder": "22.13.1",
         "electron-notarize": "1.0.0"
     },
     "devDependencies": {

--- a/packages/rnv-engine-rn-electron/src/sdks/sdk-electron/index.js
+++ b/packages/rnv-engine-rn-electron/src/sdks/sdk-electron/index.js
@@ -222,7 +222,7 @@ const exportElectron = async (c) => {
 
     await executeAsync(
         c,
-        `npx -p electron-builder electron-builder --config ${path.join(
+        `npx electron-builder --config ${path.join(
             platformBuildDir,
             'electronConfig.json'
         )}`

--- a/packages/rnv-engine-rn-macos/package.json
+++ b/packages/rnv-engine-rn-macos/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnv/engine-rn-macos",
-    "version": "0.32.0-feat-engines-merged-16",
+    "version": "0.32.0-feat-rn-electron-0",
     "description": "ReNative Engine to build react-native macOS platform.",
     "keywords": [
         "react-native-macos"

--- a/packages/rnv-engine-rn-next/package.json
+++ b/packages/rnv-engine-rn-next/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnv/engine-rn-next",
-    "version": "0.32.0-feat-engines-merged-16",
+    "version": "0.32.0-feat-rn-electron-0",
     "description": "ReNative Engine to build next based platforms with react native support.",
     "keywords": [
         "nextjs",

--- a/packages/rnv-engine-rn-tvos/package.json
+++ b/packages/rnv-engine-rn-tvos/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnv/engine-rn-tvos",
-    "version": "0.32.0-feat-engines-merged-16",
+    "version": "0.32.0-feat-rn-electron-0",
     "description": "ReNative Engine to build react-native tvos platform.",
     "keywords": [
         "react-native"

--- a/packages/rnv-engine-rn-web/package.json
+++ b/packages/rnv-engine-rn-web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnv/engine-rn-web",
-    "version": "0.32.0-feat-engines-merged-16",
+    "version": "0.32.0-feat-rn-electron-0",
     "description": "ReNative Engine to build web based platforms with react native support.",
     "keywords": [
         "react-native"

--- a/packages/rnv-engine-rn-windows/package.json
+++ b/packages/rnv-engine-rn-windows/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnv/engine-rn-windows",
-    "version": "0.32.0-feat-engines-merged-16",
+    "version": "0.32.0-feat-rn-electron-0",
     "description": "ReNative Engine to build for Windows platform with react native support.",
     "keywords": [
         "react-native",

--- a/packages/rnv-engine-rn/package.json
+++ b/packages/rnv-engine-rn/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnv/engine-rn",
-    "version": "0.32.0-feat-engines-merged-16",
+    "version": "0.32.0-feat-rn-electron-0",
     "description": "ReNative Engine to build react-native based platforms.",
     "keywords": [
         "react-native"

--- a/packages/rnv/coreTemplateFiles/renative.templates.json
+++ b/packages/rnv/coreTemplateFiles/renative.templates.json
@@ -5,35 +5,35 @@
     },
     "engineTemplates": {
         "@rnv/engine-rn": {
-            "version": "0.32.0-feat-engines-merged-16",
+            "version": "0.32.0-feat-rn-electron-0",
             "id": "engine-rn"
         },
         "@rnv/engine-rn-tvos": {
-            "version": "0.32.0-feat-engines-merged-16",
+            "version": "0.32.0-feat-rn-electron-0",
             "id": "engine-rn-tvos"
         },
         "@rnv/engine-rn-web": {
-            "version": "0.32.0-feat-engines-merged-16",
+            "version": "0.32.0-feat-rn-electron-0",
             "id": "engine-rn-web"
         },
         "@rnv/engine-rn-next": {
-            "version": "0.32.0-feat-engines-merged-16",
+            "version": "0.32.0-feat-rn-electron-0",
             "id": "engine-rn-next"
         },
         "@rnv/engine-rn-electron": {
-            "version": "0.32.0-feat-engines-merged-16",
+            "version": "0.32.0-feat-rn-electron-0",
             "id": "engine-rn-electron"
         },
         "@rnv/engine-lightning": {
-            "version": "0.32.0-feat-engines-merged-16",
+            "version": "0.32.0-feat-rn-electron-0",
             "id": "engine-lightning"
         },
         "@rnv/engine-rn-macos": {
-            "version": "0.32.0-feat-engines-merged-16",
+            "version": "0.32.0-feat-rn-electron-0",
             "id": "engine-rn-macos"
         },
         "@rnv/engine-rn-windows": {
-            "version": "0.32.0-feat-engines-merged-16",
+            "version": "0.32.0-feat-rn-electron-0",
             "id": "engine-rn-windows"
         }
     },

--- a/packages/rnv/package.json
+++ b/packages/rnv/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rnv",
-    "version": "0.32.0-feat-engines-merged-16",
+    "version": "0.32.0-feat-rn-electron-0",
     "description": "💻 CLI for ReNative (https://www.npmjs.com/package/renative). Supports `iOS`, `tvOS`, `Android`, `Android TV`, `Android Wear`, `Web`, `Tizen TV`, `Tizen Watch`, `LG webOS`, `macOS/OSX`, `Windows`, `KaiOS`, `FirefoxOS`, `Firefox TV`",
     "keywords": [
         "android tv",

--- a/packages/rnv/pluginTemplates/renative.plugins.json
+++ b/packages/rnv/pluginTemplates/renative.plugins.json
@@ -23,7 +23,7 @@
             "version": "npm:react-native-tvos@0.63.4-0"
         },
         "renative": {
-            "version": "0.32.0-feat-engines-merged-16",
+            "version": "0.32.0-feat-rn-electron-0",
             "webpack": {
                 "modulePaths": [
                     "node_modules/renative"

--- a/website/versioned_docs/version-0.31/changelog.md
+++ b/website/versioned_docs/version-0.31/changelog.md
@@ -8248,6 +8248,310 @@ rnv run -p android
 - none
 
   
+## v0.32.0-feat-rn-electron-0 (2021-11-10)
+
+### Fixed
+
+- chore(rn-electron): upgrade electron-builder version to 22.13.1
+- fix(rn-electron): revert electron-builder command execution
+- Merge pull request #721 from pavjacko/feat/plugins_support
+- Merge branch 'develop' of github.com:pavjacko/renative into develop
+- rename macos scheme
+- fixed web path
+- Merge branch 'feat/engines-merged' into develop
+- Merge branch 'feat/engines-merged' of github.com:pavjacko/renative into feat/engines-merged
+- added missing dep, fixed new avd bin path
+- Merge pull request #696 from whenmoon/fix-navigation-from-drawer-to-home
+- Merge branch 'feat/engines-merged' of github.com:pavjacko/renative into feat/engines-merged
+- [fix] switch to engine-rn (catalyst mode) fro macos
+- 0.32.0-feat-engines-merged-16
+- chore(rn-electron): change how electron-builder command is executed
+- [fix] sanity runner
+- Merge pull request #722 from pavjacko/feat/kotlin_version
+- Merge pull request #724 from pavjacko/chore/merge_bucket
+- Merge pull request #675 from pavjacko/dependabot/npm_and_yarn/website/hosted-git-info-2.8.9
+- Merge pull request #688 from pavjacko/dependabot/npm_and_yarn/website/postcss-7.0.36
+- Merge pull request #692 from pavjacko/dependabot/npm_and_yarn/website/set-getter-0.1.1
+- Merge pull request #706 from pavjacko/dependabot/npm_and_yarn/website/path-parse-1.0.7
+- Merge pull request #710 from pavjacko/dependabot/npm_and_yarn/website/color-string-1.6.0
+- Merge pull request #711 from pavjacko/dependabot/npm_and_yarn/website/url-parse-1.5.3
+- Merge pull request #714 from pavjacko/dependabot/npm_and_yarn/website/prismjs-1.25.0
+- Merge pull request #723 from pavjacko/chore/merge_bucket
+- better readability for adb port support
+- Merge pull request #686 from AnpherZhang/develop
+- Merge pull request #684 from iMokhles/patch-1
+- Merge pull request #676 from soroushchehresa/patch-1
+- added support for kotlin version inject
+- added plugins support
+- 0.32.0-feat-engines-merged-15
+- support for macos builds
+- plugin fixes
+- [fix] index.html custom override not working
+- 0.32.0-feat-engines-merged-14
+- macos runner
+- Merge branch 'feat/engines-merged' of github.com:pavjacko/renative into feat/engines-merged
+- macos support
+- 0.32.0-feat-engines-merged-13
+- fix(AndroidTV:engine-tvos): A few more plugin sanitization fixes on tvOS engine
+- feat(engine-macos): Add deploy task to macos engine to be able to trigger build hook
+- fix(AndroidTV:engine-tvos): Plugin santization added to tvos engine as it exists on regular rn engine
+- Merge branch 'feat/engines-merged' of github.com:pavjacko/renative into feat/engines-merged
+- M1 support for electron, macos support fixes
+- [chore] 0.32.0-feat-engines-merged-12
+- [chore] update dependencies
+- add macos support for engine-rn
+- [chore] 0.32.0-feat-engines-merged-11
+- soLoader crash fix for android 11
+- fix(WebOS): Some fixes for webOS SDK and emulator detection
+- fix(RN Windows): Fix engine internals to use recently added monrepoRoot prop
+- fix(EngineNext): Fix adapter and add next.config to coreTemplateFiles
+- 0.32.0-feat-engines-merged-10
+- [feat] ability to make unsigned builds
+- 0.32.0-feat-engines-merged-9
+- [fix] avoid infinite loop if module resolution gets corrupted
+- 0.32.0-feat-engines-merged-8
+- Merge pull request #715 from pavjacko/feat/custom-mono-root
+- feat: add config prop `monoRoot`
+- Bump prismjs from 1.23.0 to 1.25.0 in /website
+- 0.32.0-feat-engines-merged-7
+- skip rn packaging id bundleAssets is false
+- 0.32.0-feat-engines-merged-6
+- [fix] allow auto restart if --ci
+- 0.32.0-feat-engines-merged-5
+- Merge branch 'feat/engines-merged' of https://github.com/pavjacko/renative into feat/engines-merged
+- chore: remove extraNodeModules spread in metro config adapter
+- chore: bump next-transpile-modules
+- chore: bump react-native-vector-icons
+- activate aab in build phases, ignore for run
+- [fix] run on device
+- 0.32.0-feat-engines-merged-4
+- refactor(RN Windows): Remove newer react native cli dependency, because it was needed for rn 0.64
+- fix(RN Windows): Fix inccorect property names in renative config
+- 0.32.0-feat-engines-merged-3
+- fix(RN Windows): Fixes needed for bootstrapping new projects and using RN Windows in them
+- 0.32.0-feat-engines-merged-2
+- feat(Xbox): Added Xbox as a platform that runs on RN Windows engine
+- added @babel/helper-builder-react-jsx-experimental dep
+- Merge branch 'feat/engines-merged' of https://github.com/pavjacko/renative into feat/engines-merged
+- 0.32.0-feat-engines-merged-1
+- Merge branch 'feat/include_asdk_env_locations' into feat/engines-merged
+- fix(Windows): Add windows engine as a dev dependency to app package
+- Merge branch 'feat/engines-merged' of github.com:pavjacko/renative into feat/engines-merged
+- add helper builder dep
+- fix(Windows): Default app icon assets not getting picked up issue fix
+- fix(Windows): Unify RN Windows engine version with other packages versions
+- Merge branch 'feat/react-native-windows' into feat/engines-merged
+- 0.32.0-feat-asdk-7
+- fix(Xbox): Add Xbox application size and focus navigation enablement fix for apps using RN Windows engine
+- Merge branch 'feat/react-native-windows' into feat/engines-merged
+- 0.32.0-feat-rnwin-5
+- fix(platformAssets): Platform assets not getting copied over to the project, because default ones exist fix
+- 0.32.0-feat-asdk-6
+- 0.32.0-feat-asdk-5
+- 0.32.0-feat-rnwin-4
+- fix(Logs): Remove console.logs accidentally added by the previous commit
+- improvement(Docs): Updated documentation for configuration properties accepted by RN Windows
+- fix(clean): Fix rnv clean cache command on Windows machines
+- 0.32.0-feat-asdk-4
+- 0.32.0-feat-asdk-3
+- merge with engines
+- 0.32.0-feat-asdk-3
+- 0.32.0-feat-rnwin-3
+- Merge branch 'feat/react-native-windows' of github.com:pavjacko/renative into feat/react-native-windows
+- fix(RN Windows): Fix namespace being assigned a title with spaces in between
+- 0.32.0-feat-rnwin-2
+- fix(RN Windows): Fix existing metro config in project getting overriden
+- fix(RN Windows): Fix overrides of the default project files
+- 0.32.0-feat-rnwin-1
+- fix(RN Windows): Fix documentation of RN Windows engine
+- 0.32.0-feat-rnwin-0
+- fix(RN Windows): Fixes for RN Windows engine copied over from engines merged branch
+- chore (hello-world template): upgraded react-navigation `core`and `native` versions to match ones required by plugin templates
+- fix (tvos: rnv templates buildSchemes): remove redundant property `scheme` from `releae` buildScheme
+- chore (rn-macos engine): revert `inlineRequires` property to `false`in metro config
+- fix(RN Windows): Fixes needed for RN Windows engine to run in engines merged branch
+- 0.32.0-feat-asdk-2
+- Merge branch 'feat/react-native-windows' into feat/engines-merged
+- refactor(RN): Downgrade react native version to the maximum supported one by the tvos engine
+- Merge pull request #690 from kasinskas/feat/lightning-engine
+- Merge branch 'feat/engines-merged' of https://github.com/pavjacko/renative into feat/lightning-engine
+- update dep locks
+- Merge branch 'feat/include_asdk_env_locations' into feat/merges
+- Merge branch 'feat/react-native-windows' into feat/merges
+- Merge branch 'feat/engine-macos' into feat/merges
+- Merge branch 'feat/engine-tvos' into feat/merges
+- Merge branch 'fix/windows-android-builds' into feat/merges
+- Merge branch 'fix/android-bundler' into feat/merges
+- Merge branch 'feat/appDelegate-extensions' into feat/merges
+- Merge branch 'fix/resolve-monorepo-assets-paths' into feat/merges
+- Bump url-parse from 1.5.1 to 1.5.3 in /website
+- Bump color-string from 1.5.4 to 1.6.0 in /website
+- expose fs api
+- fix(Export): Fix some issues with exporting a package
+- 0.32.0-feat-asdk-1
+- fixed conflicts
+- 0.32.0-feat-asdk-0
+- fixed typo
+- added common env variable locations for Android SDK
+- improve(Export): Add install and sign scripts as part of of export function for now
+- feat(Windows Export): Added export command logic for RN Windows engine
+- Bump path-parse from 1.0.6 to 1.0.7 in /website
+- feat(App Title): getAppTitle from renative is now used to set the title of the application
+- 0.32.0-feat-rnmacos-8
+- feat(App Icons): ReNative icons added for RN Windows applications as the default icons
+- chore (macos engines): make `rn-electron` default macos engine and change the engine to `rn-macos` only for hello-world app
+- fix (rn-macos, rn-electron engines): make it possible to run macos platform on both engines
+- chore (renative): add constants which determines current engine
+- fix(Icons): Fixed linking for icon files
+- fix (rn-macos engine): remove `ios` extension to fix app crashing on launch
+- refactor (rn-macos engine): change `overview` field for the engine
+- fix(Plugins): Update navigation and reanimated plugins to versions, which support react native windows
+- chore (rn-macos engine): added more extensions for the macos platform
+- improvement (rn-tvos engine): add default metro.config.rnt.js file for tvOS platform and additional constant `RNT_CLI_CONFIG_NAME`
+- refactor (rn-macos engine): fix a comment
+- chore (plugin overrides): add comments to react-native-community override to easily find the override
+- fix(Windows Builds): Fixed renative build cli function for Windows
+- 0.32.0-feat-tvos-4
+- fix(Reanimated plugin): Bump up version for the plugin as it causes a crash within react navigation
+- fix(Windows Release): Cleaned up cache clearing command
+- fix(Windows Release): Added additional cache clearing which seems to have fixed release builds via CLI
+- fix(versions): Revert version upgrade in order to make this a viable PR for merge
+- fix (rn-tvos engine, androidtv/firetv): fix app deployment in release mode
+- 0.32.0-feat-winbuilds-1
+- Merge branch 'fix/windows-android-builds' of https://github.com/pavjacko/renative into fix/windows-android-builds
+- fix(Windows Workspace): Fix issues with workspace config on Windows caused by my previous commit
+- fix (rn-tvos engine, tvOS: @react-native-community overrides): remove extra parameter from a function call to fix running an app on tvOS simulator
+- 0.32.0-feat-winbuilds-0
+- fix (rn-tvos engine, tvOS): fix tvos app deployment to devices
+- fix(Windows): Fixing android release builds execution on windows
+- refactor (rn-tvos engine): rename xcode workspace file name to correct one
+- fix (rn-tvos engine): fix the issue where tvos simulator and app wouldn't open when running in release mode
+- refactor (rn-engine tvos): remove unused files
+- fix(Windows Build): Fixing debug builds via CLI
+- 0.32.0-feat-tvos-3
+- 0.32.0-feat-tvos.2
+- chore (buildHooks): add rn-tvos engine package.json to `updateVersions` build hook
+- chore (rnv templates): add "INTERNET" to `includedPermissions` to fix android/androidtv connection to bundler
+- improvement(Windows Clean): Added temporary files cleaning to the build process
+- 0.32.0-feat-rnmacos-7
+- improvement (rn-macos engine): add default metro.config.rnm.js file for macOS platform and additional constant `RNM_CLI_CONFIG_NAME`
+- chore (react-native-reanimated): downgrade plugin version and add temp overrides for macOS platform to work properly
+- fix(Windows Run): Fixing -r flag run process hang on Windows
+- 0.32.0-feat-rnmacos-6
+- 0.32.0-feat-rnmacos-5
+- chore (rn-macos engine): add few more default properties to entitlements
+- 0.32.0-feat-rnmacos-4
+- fix (rn-macos engine): fix code signing entitlements and add default properties to entitlements.plist
+- fix (template-hello-world: macOS): removed `macos` specific file
+- improvements (rn-macos engine): add missing default  app icons to `assets`
+- fix (rn-macos engine): change engine `projectDirName` from `project` to empty string so application assets would be copied properly
+- chore (rn-macos engine): add `macos`to missing engines config
+- 0.32.0-feat-rnmacos-3
+- fix (rn-macos engine): fix missed things for specific metro config
+- 0.32.0-feat-rnmacos-2
+- refactor (rn-macos engine): remove unused file
+- chore (rn-macos engine): add `rnm` specific metro config
+- fix (rn-macos engine: `package` script): change platform from `ios`to `macos`when packaging
+- fix (rn-template-hello-world, macOS: app): add a check to not render a CastButton for `desktop`platforms
+- chore (app/rnv/hello-world): upgrade `react-navigation/stack`, `react-navigation/native`, `react-native-reanimated` and `react-native-safe-area-context` versions for macOS to work properly
+- fix (rn-macos engine): dynamic app title
+- feat (rn-macos): inject dynamic application title to podfile and xcode project configuration
+- feat (rn-macos engine): add storyboard parser so it would be possible to inject dynamic application title
+- fix(Windows Navigation): Fix issues with react navigation
+- 0.32.0-feat-rnmacos-1
+- chore (builhooks): add rn-macos engine to `updateVersions` hook
+- fix(Windows Metro): Fix bundle placing
+- 0.32.0-feat-rnmacos-0
+- fix (rn-macos engine): add `teamID` to `exportOptions`
+- fix (rn-macos engine): AppDelegate script for bundle
+- improvement (rn-macos engine): add `export` command and make possible to run app in release mode via cli
+- fix(Windows Metro): Fix the issue with packager running in a separate window
+- 0.32.0-feat-tvos.1
+- 0.32.0-feat-tvos.0
+- 0.32.0-feat-tvos.0
+- set default engine as engine-rn-tvos for native tvs
+- Add android tv and firetv to tvos engine
+- fix android based platforms connection to bundler, add dedicated metro config for tvos engine
+- [fix] total plugin count
+- improvement (rn-macos engine): add `package` and `build` rnv commands
+- fix(Windows Metro): Fix custom server port config via renative for app to run
+- refactor (rn-macos engine): clean up some code and rename some files
+- chore (rn-macos engine): add missing macos engine package to both `blank`and `hello-world`templates renative config
+- improvement (rn-macos engine: AppDelegate): dynamic bundle url
+- fix (rn-macos engine: xcode project configuration): remove unused children from frameworks
+- improve(Run): Updated Windows SDK to allow for more configuration via renative.json
+- fix(Run): Windows application launches and runs using rnv
+- fix (rn-macos engine): fix fonts
+- 0.32.0-feat-lightning-1
+- fix(Run): Initial issues fixing for metro, that prevent bundler from starting
+- [feat] add missing includedPlugins warning
+- improvement (renative package): add Api constant for `engine-rn-macos`
+- improvement (rn-macos engine): remove ios/tvos related stuff from xcodeParser, remove unecessary property from template apps renative.json
+- improvement (rn-macos engine): remove unused swiftParser
+- fix (rn-macos engine): fix runtime errors when running the app by changing the platform to correct one in bundle url
+- [fix] detox fixes
+- fix(Run): Windows builds the project successfully with rnv
+- chore (rn-macos engine): removed some ios/tvos platforms related configuration from xcode project config
+- improvement (rn-macos engine): add `run` command
+- chore(Lightning): bump lightning cli
+- improvement (rn-macos engine): add `start` command
+- fix(Configure): Don't override the metro config by default
+- chore: remove ios target from rn-macos engine xcode project
+- feat(Configure): Initial version of configure command for RN WIndows Engine
+- feat (macos engine): initial engine setup, `configure` command
+- temp(RN Windows): Rewriting configure from RN Windows CLI
+- improvement(Configure): Working on Windows configure task
+- improvement(Windows Engine): Copied the generated logic into templates and prepared for initial setup
+- remove some unneded cli overrides
+- bring back removed metro config
+- add missing tasks to engine-rn-tvos
+- remove tvos from engine-rn
+- tvos as separate engine
+- fix: navigating home from navigation drawer
+- feat(RNW): Added packages needed for react native windows
+- fix(Lightning): required build files not always being generated
+- feat: enable hosted param for lightning and run the app to simulator
+- feat: package lightning apps using rnv build
+- chore: dont hoist lightning cli dep
+- fix: change lightning esbuild override targets, since previous didnt match
+- feat(Lightning): add configure task
+- chore: add lng engine templates
+- fix(iOS:RN Engine): After version bump up for react-native iOS build failing fix
+- improvement(RN Engine tvOS): Added tvOS engine to templates and other places where other engines are specified
+- Bump set-getter from 0.1.0 to 0.1.1 in /website
+- fix(Lightning): override es5 configs to support extensions and different entry files
+- improvement: add current engine to env variables
+- feat(Lightning): allow specifying build target in renative config
+- improvement(Lightning): override entry file location to match other platforms
+- improvement(Lightning): use platform ports
+- chore: add lightning engine references
+- improvement(Lightning): add build task
+- feat(Lightning): add webos to lightning engine
+- feat(Lightning): resolve .lng extensions
+- feat(Lightning): override hardcoded served build folder path in lng package
+- fix(Lightning): enable relative path for build folder
+- chore: bump lightning sdk package and add cli
+- Bump postcss from 7.0.35 to 7.0.36 in /website
+- feat(CarPlay): Add CarPlay plugin to the list of possible plugins
+- feat(AppDelegate): Added extensions for application and methods needed for CarPlay support
+- [ReNative][Android][Debug-RunAndroid] support rnv run -p android -t 127.0.0.1:7555
+- [fix] resolve paths in monorepo projects
+- engine tvos wip
+- [fix] Xcode 12.5 fix edge cases with RN Pod override
+- Update renative.json
+- fixed web and webtv debug enviroment
+- Fix FireTV documentation link
+- Bump hosted-git-info from 2.8.8 to 2.8.9 in /website
+
+### Added Features
+
+- none
+
+### Breaking Changes
+
+- none
+
+  
 ## v0.32.0-feat-rnmacos-0 (2021-7-22)
 
 ### Fixed

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"7zip-bin@~5.0.3":
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/7zip-bin/-/7zip-bin-5.0.3.tgz#bc5b5532ecafd923a61f2fb097e3b108c0106a3f"
-  integrity sha512-GLyWIFBbGvpKPGo55JyRZAo4lVbnBiD52cKlw/0Vt+wnmKvWJkpZvsjVoaIolyBXDeAQKSicRtqFNPem9w0WYA==
+"7zip-bin@~5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/7zip-bin/-/7zip-bin-5.1.1.tgz#9274ec7460652f9c632c59addf24efb1684ef876"
+  integrity sha512-sAP4LldeWNz0lNzmTird3uWfFDWWTeg6V/MsmyyLR9X1idwKBWIgt/ZvinqQldJm3LecKEs1emkbquO6PCiLVQ==
 
 "@ampproject/toolbox-core@^1.0.1", "@ampproject/toolbox-core@^1.1.1":
   version "1.1.1"
@@ -1861,6 +1861,17 @@
     global-agent "^2.0.2"
     global-tunnel-ng "^2.7.1"
 
+"@electron/universal@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@electron/universal/-/universal-1.0.5.tgz#b812340e4ef21da2b3ee77b2b4d35c9b86defe37"
+  integrity sha512-zX9O6+jr2NMyAdSkwEUlyltiI4/EBLu2Ls/VD3pUQdi3cAYeYfdQnT2AJJ38HE4QxLccbU13LSpccw1IWlkyag==
+  dependencies:
+    "@malept/cross-spawn-promise" "^1.1.0"
+    asar "^3.0.3"
+    debug "^4.3.1"
+    dir-compare "^2.4.0"
+    fs-extra "^9.0.1"
+
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz#ecf7f6ce6b004e9f942b098d92200be4a4b1c845"
@@ -3519,6 +3530,23 @@
     url-polyfill "^1.1.10"
     whatwg-fetch "^3.0.0"
 
+"@malept/cross-spawn-promise@^1.1.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz#504af200af6b98e198bce768bc1730c6936ae01d"
+  integrity sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+"@malept/flatpak-bundler@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz#e8a32c30a95d20c2b1bb635cc580981a06389858"
+  integrity sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==
+  dependencies:
+    debug "^4.1.1"
+    fs-extra "^9.0.0"
+    lodash "^4.17.15"
+    tmp-promise "^3.0.2"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -4350,7 +4378,7 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/debug@^4.1.5":
+"@types/debug@^4.1.6":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
   integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
@@ -4367,10 +4395,10 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
-"@types/fs-extra@^9.0.1":
-  version "9.0.12"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.12.tgz#9b8f27973df8a7a3920e8461517ebf8a7d4fdfaf"
-  integrity sha512-I+bsBr67CurCGnSenZZ7v94gd3tc3+Aj2taxMT4yu4ABLuOgOjeFxX3dokG24ztSRg5tnT00sL8BszO7gSMoIw==
+"@types/fs-extra@^9.0.11":
+  version "9.0.13"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.13.tgz#7594fbae04fe7f1918ce8b3d213f74ff44ac1f45"
+  integrity sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==
   dependencies:
     "@types/node" "*"
 
@@ -4486,6 +4514,14 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/plist@^3.0.1":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/plist/-/plist-3.0.2.tgz#61b3727bba0f5c462fe333542534a0c3e19ccb01"
+  integrity sha512-ULqvZNGMv0zRFvqn8/4LSPtnmN4MfhlPNtJCTpKuIIxGVGZ2rYWzFXrvEBoh9CVyqSE7D6YFRJ1hydLHI6kbWw==
+  dependencies:
+    "@types/node" "*"
+    xmlbuilder ">=11.0.1"
+
 "@types/prettier@^2.0.0":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.2.tgz#fc8c2825e4ed2142473b4a81064e6e081463d1b3"
@@ -4559,6 +4595,11 @@
   dependencies:
     source-map "^0.6.1"
 
+"@types/verror@^1.10.3":
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/@types/verror/-/verror-1.10.5.tgz#2a1413aded46e67a1fe2386800e291123ed75eb1"
+  integrity sha512-9UjMCHK5GPgQRoNbqdLIAvAy0EInuiqbW0PBMtVP6B5B2HQJlvoJHM+KodPZMEjOa5VkSc+5LH7xy+cUzQdmHw==
+
 "@types/webpack-sources@*":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-3.2.0.tgz#16d759ba096c289034b26553d2df1bf45248d38b"
@@ -4592,10 +4633,17 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/yargs@^15.0.0", "@types/yargs@^15.0.5":
+"@types/yargs@^15.0.0":
   version "15.0.14"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.14.tgz#26d821ddb89e70492160b66d10a0eb6df8f6fb06"
   integrity sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^17.0.1":
+  version "17.0.5"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.5.tgz#1e7e59a88420872875842352b73618f5e77e835f"
+  integrity sha512-4HNq144yhaVjJs+ON6A07NEoi9Hh0Rhl/jI9Nt/l/YRjt+T6St/QK3meFARWZ8IgkzoD1LC0PdTdJenlQQi2WQ==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -5088,6 +5136,11 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -5143,38 +5196,40 @@ anymatch@^3.0.0, anymatch@^3.0.3, anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-app-builder-bin@3.5.10:
-  version "3.5.10"
-  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-3.5.10.tgz#4a7f9999fccc0c435b6284ae1366bc76a17c4a7d"
-  integrity sha512-Jd+GW68lR0NeetgZDo47PdWBEPdnD+p0jEa7XaxjRC8u6Oo/wgJsfKUkORRgr2NpkD19IFKN50P6JYy04XHFLQ==
+app-builder-bin@3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-3.7.1.tgz#cb0825c5e12efc85b196ac3ed9c89f076c61040e"
+  integrity sha512-ql93vEUq6WsstGXD+SBLSIQw6SNnhbDEM0swzgugytMxLp3rT24Ag/jcC80ZHxiPRTdew1niuR7P3/FCrDqIjw==
 
-app-builder-lib@22.8.1:
-  version "22.8.1"
-  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-22.8.1.tgz#02cd14c0a83d3a758675d28c327731832b2c0bc1"
-  integrity sha512-D/ac1+vuGIAAwEeTtXl8b+qWl7Gz/IQatFyzYl2ocag/7N8LqUjKzZFJJISQPWt6PFDPDH0oCj8/GMh63aV0yw==
+app-builder-lib@22.13.1:
+  version "22.13.1"
+  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-22.13.1.tgz#9beee0dd3df32fcce303b933d187bf986efe3381"
+  integrity sha512-TsUe7gCdH1cnSknUcqwVRAAxsFxsxcU/BJvnKR8ASzjaZtePW7MU+AEaDVDUURycgYxQ9XeymGjmuQGS32jcbw==
   dependencies:
-    "7zip-bin" "~5.0.3"
+    "7zip-bin" "~5.1.1"
     "@develar/schema-utils" "~2.6.5"
+    "@electron/universal" "1.0.5"
+    "@malept/flatpak-bundler" "^0.4.0"
     async-exit-hook "^2.0.1"
     bluebird-lst "^1.0.9"
-    builder-util "22.8.1"
-    builder-util-runtime "8.7.2"
+    builder-util "22.13.1"
+    builder-util-runtime "8.8.1"
     chromium-pickle-js "^0.2.0"
-    debug "^4.2.0"
-    ejs "^3.1.3"
-    electron-publish "22.8.1"
-    fs-extra "^9.0.1"
-    hosted-git-info "^3.0.5"
-    is-ci "^2.0.0"
-    isbinaryfile "^4.0.6"
-    js-yaml "^3.14.0"
-    lazy-val "^1.0.4"
+    debug "^4.3.2"
+    ejs "^3.1.6"
+    electron-osx-sign "^0.5.0"
+    electron-publish "22.13.1"
+    fs-extra "^10.0.0"
+    hosted-git-info "^4.0.2"
+    is-ci "^3.0.0"
+    isbinaryfile "^4.0.8"
+    js-yaml "^4.1.0"
+    lazy-val "^1.0.5"
     minimatch "^3.0.4"
-    normalize-package-data "^2.5.0"
-    read-config-file "6.0.0"
+    read-config-file "6.2.0"
     sanitize-filename "^1.6.3"
-    semver "^7.3.2"
-    temp-file "^3.3.7"
+    semver "^7.3.5"
+    temp-file "^3.4.0"
 
 appdirsjs@^1.2.4:
   version "1.2.5"
@@ -5220,6 +5275,11 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 aria-query@^3.0.0:
   version "3.0.0"
@@ -5397,6 +5457,18 @@ asap@^2.0.0, asap@~2.0.3, asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
+
+asar@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/asar/-/asar-3.1.0.tgz#70b0509449fe3daccc63beb4d3c7d2e24d3c6473"
+  integrity sha512-vyxPxP5arcAqN4F/ebHd/HhwnAiZtwhglvdmc7BR2f0ywbVNTOpSeyhLDbGXtE/y58hv1oC75TaNIXutnsOZsQ==
+  dependencies:
+    chromium-pickle-js "^0.2.0"
+    commander "^5.0.0"
+    glob "^7.1.6"
+    minimatch "^3.0.4"
+  optionalDependencies:
+    "@types/glob" "^7.1.1"
 
 asn1.js@^5.2.0:
   version "5.4.1"
@@ -6085,7 +6157,7 @@ bluebird@2.x:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
   integrity sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=
 
-bluebird@3.7.2, bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.4, bluebird@^3.5.5, bluebird@^3.7.2:
+bluebird@3.7.2, bluebird@^3.5.0, bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.4, bluebird@^3.5.5, bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -6156,19 +6228,19 @@ boxen@^1.2.1:
     term-size "^1.2.0"
     widest-line "^2.0.0"
 
-boxen@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/boxen/-/boxen-4.2.0.tgz#e411b62357d6d6d36587c8ac3d5d974daa070e64"
-  integrity sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==
+boxen@^5.0.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-5.1.2.tgz#788cb686fc83c1f486dfa8a40c68fc2b831d2b50"
+  integrity sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==
   dependencies:
     ansi-align "^3.0.0"
-    camelcase "^5.3.1"
-    chalk "^3.0.0"
-    cli-boxes "^2.2.0"
-    string-width "^4.1.0"
-    term-size "^2.1.0"
-    type-fest "^0.8.1"
+    camelcase "^6.2.0"
+    chalk "^4.1.0"
+    cli-boxes "^2.2.1"
+    string-width "^4.2.2"
+    type-fest "^0.20.2"
     widest-line "^3.1.0"
+    wrap-ansi "^7.0.0"
 
 bplist-creator@0.0.8:
   version "0.0.8"
@@ -6361,6 +6433,11 @@ buffer-equal@0.0.1:
   resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-0.0.1.tgz#91bc74b11ea405bc916bc6aa908faafa5b4aac4b"
   integrity sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs=
 
+buffer-equal@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-1.0.0.tgz#59616b498304d556abd466966b22eeda3eca5fbe"
+  integrity sha1-WWFrSYME1Var1GaWayLu2j7KX74=
+
 buffer-fill@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
@@ -6398,7 +6475,7 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-buffer@^5.2.0, buffer@^5.5.0:
+buffer@^5.1.0, buffer@^5.2.0, buffer@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -6406,33 +6483,34 @@ buffer@^5.2.0, buffer@^5.5.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
-builder-util-runtime@8.7.2:
-  version "8.7.2"
-  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.7.2.tgz#d93afc71428a12789b437e13850e1fa7da956d72"
-  integrity sha512-xBqv+8bg6cfnzAQK1k3OGpfaHg+QkPgIgpEkXNhouZ0WiUkyZCftuRc2LYzQrLucFywpa14Xbc6+hTbpq83yRA==
+builder-util-runtime@8.8.1:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.8.1.tgz#d6e2b5f27723a7606f381e52a3000dadb1d6e4a9"
+  integrity sha512-xHxAzdsJmMV8m/N+INzYUKfyJASeKyKHnA1uGkY8Y8JKLI/c4BG+If+L0If2YETv96CiRASkvd02tIt2pvrchQ==
   dependencies:
-    debug "^4.1.1"
+    debug "^4.3.2"
     sax "^1.2.4"
 
-builder-util@22.8.1:
-  version "22.8.1"
-  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-22.8.1.tgz#efdfb327dbc22c59aa1e2f55adbe0e771086e839"
-  integrity sha512-LZG+E1xszMdut5hL5h7RkJQ7yOsQqdhJYgn1wvOP7MmF3MoUPRNDiRodLpYiWlaqZmgYhcfaipR/Mb8F/RqK8w==
+builder-util@22.13.1:
+  version "22.13.1"
+  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-22.13.1.tgz#fb2165c725b9405f0605a765cf91ec1870995ada"
+  integrity sha512-gMdoW9aQbWYxuQ4k4jT4An1BTo/hWzvsdv3pwNz18iNYnqn9j+xMllQOg9CHgfQYKSUd8VuMsZnbCvLO4NltYw==
   dependencies:
-    "7zip-bin" "~5.0.3"
-    "@types/debug" "^4.1.5"
-    "@types/fs-extra" "^9.0.1"
-    app-builder-bin "3.5.10"
+    "7zip-bin" "~5.1.1"
+    "@types/debug" "^4.1.6"
+    "@types/fs-extra" "^9.0.11"
+    app-builder-bin "3.7.1"
     bluebird-lst "^1.0.9"
-    builder-util-runtime "8.7.2"
-    chalk "^4.1.0"
-    debug "^4.2.0"
-    fs-extra "^9.0.1"
-    is-ci "^2.0.0"
-    js-yaml "^3.14.0"
+    builder-util-runtime "8.8.1"
+    chalk "^4.1.1"
+    cross-spawn "^7.0.3"
+    debug "^4.3.2"
+    fs-extra "^10.0.0"
+    is-ci "^3.0.0"
+    js-yaml "^4.1.0"
     source-map-support "^0.5.19"
     stat-mode "^1.0.0"
-    temp-file "^3.3.7"
+    temp-file "^3.4.0"
 
 builtin-modules@^3.1.0:
   version "3.2.0"
@@ -6718,7 +6796,7 @@ camelcase@^4.0.0, camelcase@^4.1.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
-camelcase@^6.0.0:
+camelcase@^6.0.0, camelcase@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
@@ -6806,7 +6884,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -6917,7 +6995,7 @@ ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
-ci-info@^3.0.0:
+ci-info@^3.0.0, ci-info@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.2.0.tgz#2876cb948a498797b5236f0095bc057d0dca38b6"
   integrity sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==
@@ -6975,7 +7053,7 @@ cli-boxes@^1.0.0:
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
   integrity sha1-T6kXw+WclKAEzWH47lCdplFocUM=
 
-cli-boxes@^2.2.0:
+cli-boxes@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.1.tgz#ddd5035d25094fce220e9cab40a45840a440318f"
   integrity sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==
@@ -7028,6 +7106,14 @@ cli-truncate@^0.2.1:
   dependencies:
     slice-ansi "0.0.4"
     string-width "^1.0.1"
+
+cli-truncate@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-1.1.0.tgz#2b2dfd83c53cfd3572b87fc4d430a808afb04086"
+  integrity sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==
+  dependencies:
+    slice-ansi "^1.0.0"
+    string-width "^2.0.0"
 
 cli-width@^2.0.0:
   version "2.2.1"
@@ -7212,6 +7298,11 @@ colorette@^1.0.7, colorette@^1.3.0:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.3.0.tgz#ff45d2f0edb244069d3b772adeb04fed38d0a0af"
   integrity sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==
 
+colors@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
+  integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
+
 colors@^1.0.3, colors@^1.1.2, colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
@@ -7273,6 +7364,13 @@ commander@2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
+commander@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
+  dependencies:
+    graceful-readlink ">= 1.0.0"
+
 commander@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.0.tgz#545983a0603fe425bc672d66c9e3c89c42121a83"
@@ -7292,6 +7390,11 @@ commander@^4.0.1, commander@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+
+commander@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
+  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
 "commander@^6.1.0 ":
   version "6.2.1"
@@ -7330,6 +7433,11 @@ compare-func@^2.0.0:
   dependencies:
     array-ify "^1.0.0"
     dot-prop "^5.1.0"
+
+compare-version@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/compare-version/-/compare-version-0.1.2.tgz#0162ec2d9351f5ddd59a9202cba935366a725080"
+  integrity sha1-AWLsLZNR9d3VmpICy6k1NmpyUIA=
 
 compare-versions@3.6.0, compare-versions@^3.6.0:
   version "3.6.0"
@@ -7744,6 +7852,13 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
+crc@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/crc/-/crc-3.8.0.tgz#ad60269c2c856f8c299e2c4cc0de4556914056c6"
+  integrity sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==
+  dependencies:
+    buffer "^5.1.0"
+
 create-ecdh@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"
@@ -7857,7 +7972,7 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -8354,7 +8469,7 @@ debug@3.1.0, debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
@@ -8697,6 +8812,16 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+dir-compare@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/dir-compare/-/dir-compare-2.4.0.tgz#785c41dc5f645b34343a4eafc50b79bac7f11631"
+  integrity sha512-l9hmu8x/rjVC9Z2zmGzkhOEowZvW7pmYws5CWHutg8u1JgvsKWMx7Q/UODeu4djLZ4FgW5besw5yvMQnBHzuCA==
+  dependencies:
+    buffer-equal "1.0.0"
+    colors "1.0.3"
+    commander "2.9.0"
+    minimatch "3.0.4"
+
 dir-glob@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"
@@ -8737,17 +8862,34 @@ dmd@^5.0.1:
     test-value "^3.0.0"
     walk-back "^4.0.0"
 
-dmg-builder@22.8.1:
-  version "22.8.1"
-  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-22.8.1.tgz#9b3bcbbc43e5fed232525d61a5567ea4b66085c3"
-  integrity sha512-WeGom1moM00gBII6swljl4DQGrlJuEivoUhOmh8U9p1ALgeJL+EiTHbZFERlj8Ejy62xUUjURV+liOxUKmJFWg==
+dmg-builder@22.13.1:
+  version "22.13.1"
+  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-22.13.1.tgz#5a77655e691ad7e5d28fbf008c68e819e0e2bd69"
+  integrity sha512-qgfLN2fo4q2wIWNvbcKlZ71DLRDLvWIElOB7oxlSxUrMi6xhI+9v1Mh7E0FJ+r5UXhQzaQXaGuyMsQRbGgrSwg==
   dependencies:
-    app-builder-lib "22.8.1"
-    builder-util "22.8.1"
-    fs-extra "^9.0.1"
+    app-builder-lib "22.13.1"
+    builder-util "22.13.1"
+    builder-util-runtime "8.8.1"
+    fs-extra "^10.0.0"
     iconv-lite "^0.6.2"
-    js-yaml "^3.14.0"
-    sanitize-filename "^1.6.3"
+    js-yaml "^4.1.0"
+  optionalDependencies:
+    dmg-license "^1.0.9"
+
+dmg-license@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/dmg-license/-/dmg-license-1.0.9.tgz#a2fb8d692af0e30b0730b5afc91ed9edc2d9cb4f"
+  integrity sha512-Rq6qMDaDou2+aPN2SYy0x7LDznoJ/XaG6oDcH5wXUp+WRWQMUYE6eM+F+nex+/LSXOp1uw4HLFoed0YbfU8R/Q==
+  dependencies:
+    "@types/plist" "^3.0.1"
+    "@types/verror" "^1.10.3"
+    ajv "^6.10.0"
+    cli-truncate "^1.1.0"
+    crc "^3.8.0"
+    iconv-corefoundation "^1.1.6"
+    plist "^3.0.1"
+    smart-buffer "^4.0.2"
+    verror "^1.10.0"
 
 dns-equal@^1.0.0:
   version "1.0.0"
@@ -8956,6 +9098,11 @@ dotenv@^8.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
   integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
 
+dotenv@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-9.0.2.tgz#dacc20160935a37dea6364aa1bef819fb9b6ab05"
+  integrity sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==
+
 dtrace-provider@~0.8:
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.8.tgz#2996d5490c37e1347be263b423ed7b297fb0d97e"
@@ -9011,32 +9158,30 @@ ejs@^2.6.1:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
-ejs@^3.1.3:
+ejs@^3.1.6:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.6.tgz#5bfd0a0689743bb5268b3550cceeebbc1702822a"
   integrity sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==
   dependencies:
     jake "^10.6.1"
 
-electron-builder@22.8.1:
-  version "22.8.1"
-  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-22.8.1.tgz#84295190dae17b3892df7aa39ac334983aeaea06"
-  integrity sha512-Hs7KTMq1rGSvT0fwGKXrjbLiJkK6sAKDQooUSwklOkktUgWi4ATjlP0fVE3l8SmS7zcLoww2yDZonSDqxEFhaQ==
+electron-builder@22.13.1:
+  version "22.13.1"
+  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-22.13.1.tgz#419b2736c0b08f54cb024bc02cfae6b878b34fc3"
+  integrity sha512-ajlI40L60qKBBxvpf770kcjxHAccMpEWpwsHAppytl3WmWgJfMut4Wz9VUFqyNtX/9a624QTatk6TqoxqewRug==
   dependencies:
-    "@types/yargs" "^15.0.5"
-    app-builder-lib "22.8.1"
-    bluebird-lst "^1.0.9"
-    builder-util "22.8.1"
-    builder-util-runtime "8.7.2"
-    chalk "^4.1.0"
-    dmg-builder "22.8.1"
-    fs-extra "^9.0.1"
-    is-ci "^2.0.0"
-    lazy-val "^1.0.4"
-    read-config-file "6.0.0"
-    sanitize-filename "^1.6.3"
-    update-notifier "^4.1.0"
-    yargs "^15.4.1"
+    "@types/yargs" "^17.0.1"
+    app-builder-lib "22.13.1"
+    builder-util "22.13.1"
+    builder-util-runtime "8.8.1"
+    chalk "^4.1.1"
+    dmg-builder "22.13.1"
+    fs-extra "^10.0.0"
+    is-ci "^3.0.0"
+    lazy-val "^1.0.5"
+    read-config-file "6.2.0"
+    update-notifier "^5.1.0"
+    yargs "^17.0.1"
 
 electron-notarize@1.0.0:
   version "1.0.0"
@@ -9046,19 +9191,30 @@ electron-notarize@1.0.0:
     debug "^4.1.1"
     fs-extra "^9.0.1"
 
-electron-publish@22.8.1:
-  version "22.8.1"
-  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-22.8.1.tgz#747e0d7f921cd1808f999713d29f599dbb390c4f"
-  integrity sha512-zqI66vl7j1CJZJ60J+1ez1tQNQeuqVspW44JvYDa5kZbM5wSFDAJFMK9RWHOqRF1Ezd4LDeiBa4aeTOwOt9syA==
+electron-osx-sign@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/electron-osx-sign/-/electron-osx-sign-0.5.0.tgz#fc258c5e896859904bbe3d01da06902c04b51c3a"
+  integrity sha512-icoRLHzFz/qxzDh/N4Pi2z4yVHurlsCAYQvsCSG7fCedJ4UJXBS6PoQyGH71IfcqKupcKeK7HX/NkyfG+v6vlQ==
   dependencies:
-    "@types/fs-extra" "^9.0.1"
-    bluebird-lst "^1.0.9"
-    builder-util "22.8.1"
-    builder-util-runtime "8.7.2"
-    chalk "^4.1.0"
-    fs-extra "^9.0.1"
-    lazy-val "^1.0.4"
-    mime "^2.4.6"
+    bluebird "^3.5.0"
+    compare-version "^0.1.2"
+    debug "^2.6.8"
+    isbinaryfile "^3.0.2"
+    minimist "^1.2.0"
+    plist "^3.0.1"
+
+electron-publish@22.13.1:
+  version "22.13.1"
+  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-22.13.1.tgz#7d3aedf988f995c149cc620aef0772559342ea03"
+  integrity sha512-5nCXhnsqrRxP5NsZxUKjiMkcFmQglXp7i/YY4rp3h1s1psg3utOIkM29Z93YTSXicZJU1J+8811eo5HX1vpoKg==
+  dependencies:
+    "@types/fs-extra" "^9.0.11"
+    builder-util "22.13.1"
+    builder-util-runtime "8.8.1"
+    chalk "^4.1.1"
+    fs-extra "^10.0.0"
+    lazy-val "^1.0.5"
+    mime "^2.5.2"
 
 electron-to-chromium@^1.3.191, electron-to-chromium@^1.3.378, electron-to-chromium@^1.3.488, electron-to-chromium@^1.3.811:
   version "1.3.824"
@@ -10589,7 +10745,7 @@ fs-extra@^7.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.1:
+fs-extra@^9.0.0, fs-extra@^9.0.1:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
@@ -10951,12 +11107,12 @@ global-dirs@^0.1.0:
   dependencies:
     ini "^1.3.4"
 
-global-dirs@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-2.1.0.tgz#e9046a49c806ff04d6c1825e196c8f0091e8df4d"
-  integrity sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==
+global-dirs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-3.0.0.tgz#70a76fe84ea315ab37b1f5576cbde7d48ef72686"
+  integrity sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==
   dependencies:
-    ini "1.3.7"
+    ini "2.0.0"
 
 global-modules-path@^2.3.0:
   version "2.3.1"
@@ -11134,6 +11290,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
+
+"graceful-readlink@>= 1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+  integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
 growly@^1.3.0:
   version "1.3.0"
@@ -11377,14 +11538,14 @@ hosted-git-info@^2.1.4, hosted-git-info@^2.7.1:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
-hosted-git-info@^3.0.2, hosted-git-info@^3.0.5:
+hosted-git-info@^3.0.2:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-3.0.8.tgz#6e35d4cc87af2c5f816e4cb9ce350ba87a3f370d"
   integrity sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==
   dependencies:
     lru-cache "^6.0.0"
 
-hosted-git-info@^4.0.1:
+hosted-git-info@^4.0.1, hosted-git-info@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.0.2.tgz#5e425507eede4fea846b7262f0838456c4209961"
   integrity sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==
@@ -11684,6 +11845,14 @@ hyphenate-style-name@^1.0.2, hyphenate-style-name@^1.0.3:
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
   integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
 
+iconv-corefoundation@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/iconv-corefoundation/-/iconv-corefoundation-1.1.6.tgz#27c135470237f6f8d13462fa1f5eaf250523c29a"
+  integrity sha512-1NBe55C75bKGZaY9UHxvXG3G0gEp0ziht7quhuFrW3SPgZDw9HI6qvYXRSV5M/Eupyu8ljuJ6Cba+ec15PZ4Xw==
+  dependencies:
+    cli-truncate "^1.1.0"
+    node-addon-api "^1.6.3"
+
 iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -11899,10 +12068,10 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@1.3.7:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.7.tgz#a09363e1911972ea16d7a8851005d84cf09a9a84"
-  integrity sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==
+ini@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
+  integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
 
 ini@^1.3.2, ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.8"
@@ -12220,6 +12389,13 @@ is-ci@^1.0.10:
   dependencies:
     ci-info "^1.5.0"
 
+is-ci@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz#db6ecbed1bd659c43dac0f45661e7674103d1867"
+  integrity sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==
+  dependencies:
+    ci-info "^3.2.0"
+
 is-color-stop@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-color-stop/-/is-color-stop-1.1.0.tgz#cfff471aee4dd5c9e158598fbe12967b5cdad345"
@@ -12359,13 +12535,13 @@ is-installed-globally@0.1.0, is-installed-globally@^0.1.0:
     global-dirs "^0.1.0"
     is-path-inside "^1.0.0"
 
-is-installed-globally@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.3.2.tgz#fd3efa79ee670d1187233182d5b0a1dd00313141"
-  integrity sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==
+is-installed-globally@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.4.0.tgz#9a0fd407949c30f86eb6959ef1b7994ed0b7b520"
+  integrity sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==
   dependencies:
-    global-dirs "^2.0.1"
-    is-path-inside "^3.0.1"
+    global-dirs "^3.0.0"
+    is-path-inside "^3.0.2"
 
 is-interactive@^1.0.0:
   version "1.0.0"
@@ -12394,10 +12570,10 @@ is-npm@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
   integrity sha1-8vtjpl5JBbQGyGBydloaTceTufQ=
 
-is-npm@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-4.0.0.tgz#c90dd8380696df87a7a6d823c20d0b12bbe3c84d"
-  integrity sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==
+is-npm@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-5.0.0.tgz#43e8d65cc56e1b67f8d47262cf667099193f45a8"
+  integrity sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==
 
 is-number-object@^1.0.4:
   version "1.0.6"
@@ -12483,7 +12659,7 @@ is-path-inside@^2.1.0:
   dependencies:
     path-is-inside "^1.0.2"
 
-is-path-inside@^3.0.1:
+is-path-inside@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
@@ -12640,7 +12816,14 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
-isbinaryfile@^4.0.6:
+isbinaryfile@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-3.0.3.tgz#5d6def3edebf6e8ca8cae9c30183a804b5f8be80"
+  integrity sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==
+  dependencies:
+    buffer-alloc "^1.2.0"
+
+isbinaryfile@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.8.tgz#5d34b94865bd4946633ecc78a026fc76c5b11fcf"
   integrity sha512-53h6XFniq77YdW+spoRrebh0mnmTxRPTlcuIArO57lmMdq4uBKFKaeTjnb92oYWrSn/LVL+LT+Hap2tFQj8V+w==
@@ -13310,13 +13493,20 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1, js-yaml@^3.14.0, js-yaml@^3.9.0:
+js-yaml@^3.13.1, js-yaml@^3.9.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
 
 js2xmlparser@^4.0.1:
   version "4.0.1"
@@ -13502,7 +13692,7 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.0, json5@^2.1.2:
+json5@^2.1.0, json5@^2.1.2, json5@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
   integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
@@ -13643,7 +13833,7 @@ latest-version@^3.0.0:
   dependencies:
     package-json "^4.0.0"
 
-latest-version@^5.0.0, latest-version@^5.1.0:
+latest-version@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face"
   integrity sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==
@@ -13655,7 +13845,7 @@ lazy-ass@1.6.0:
   resolved "https://registry.yarnpkg.com/lazy-ass/-/lazy-ass-1.6.0.tgz#7999655e8646c17f089fdd187d150d3324d54513"
   integrity sha1-eZllXoZGwX8In90YfRUNMyTVRRM=
 
-lazy-val@^1.0.4:
+lazy-val@^1.0.4, lazy-val@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/lazy-val/-/lazy-val-1.0.5.tgz#6cf3b9f5bc31cee7ee3e369c0832b7583dcd923d"
   integrity sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==
@@ -14995,10 +15185,15 @@ mime@1.6.0, mime@^1.3.4, mime@^1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.0.3, mime@^2.4.1, mime@^2.4.4, mime@^2.4.6:
+mime@^2.0.3, mime@^2.4.1, mime@^2.4.4:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
   integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
+
+mime@^2.5.2:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -15603,6 +15798,11 @@ nocache@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/nocache/-/nocache-2.1.0.tgz#120c9ffec43b5729b1d5de88cd71aa75a0ba491f"
   integrity sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q==
+
+node-addon-api@^1.6.3:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
+  integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
 
 node-environment-flags@^1.0.5:
   version "1.0.6"
@@ -17693,7 +17893,7 @@ punycode@^1.2.4:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
-pupa@^2.0.1:
+pupa@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pupa/-/pupa-2.1.1.tgz#f5e8fd4afc2c5d97828faa523549ed8744a20d62"
   integrity sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==
@@ -18224,15 +18424,15 @@ read-cmd-shim@^1.0.1:
   dependencies:
     graceful-fs "^4.1.2"
 
-read-config-file@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/read-config-file/-/read-config-file-6.0.0.tgz#224b5dca6a5bdc1fb19e63f89f342680efdb9299"
-  integrity sha512-PHjROSdpceKUmqS06wqwP92VrM46PZSTubmNIMJ5DrMwg1OgenSTSEHIkCa6TiOJ+y/J0xnG1fFwG3M+Oi1aNA==
+read-config-file@6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/read-config-file/-/read-config-file-6.2.0.tgz#71536072330bcd62ba814f91458b12add9fc7ade"
+  integrity sha512-gx7Pgr5I56JtYz+WuqEbQHj/xWo+5Vwua2jhb1VwM4Wid5PqYmZ4i00ZB0YEGIfkVBsCv9UrjgyqCiQfS/Oosg==
   dependencies:
-    dotenv "^8.2.0"
+    dotenv "^9.0.2"
     dotenv-expand "^5.1.0"
-    js-yaml "^3.13.1"
-    json5 "^2.1.2"
+    js-yaml "^4.1.0"
+    json5 "^2.2.0"
     lazy-val "^1.0.4"
 
 "read-package-json@1 || 2", read-package-json@^2.0.0, read-package-json@^2.0.13:
@@ -19468,6 +19668,13 @@ slice-ansi@0.0.4:
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
   integrity sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=
 
+slice-ansi@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
+  integrity sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+
 slice-ansi@^2.0.0, slice-ansi@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
@@ -19487,7 +19694,7 @@ slugify@^1.3.4:
   resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.6.0.tgz#6bdf8ed01dabfdc46425b67e3320b698832ff893"
   integrity sha512-FkMq+MQc5hzYgM86nLuHI98Acwi3p4wX+a5BO9Hhw4JdK4L7WueIiZ4tXEobImPqBz2sVcV0+Mu3GRB30IGang==
 
-smart-buffer@^4.1.0:
+smart-buffer@^4.0.2, smart-buffer@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
@@ -20004,6 +20211,15 @@ string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
+string-width@^4.2.2:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string.prototype.trimend@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
@@ -20075,6 +20291,13 @@ strip-ansi@^4.0.0:
   integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -20416,7 +20639,7 @@ temp-dir@^1.0.0:
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
   integrity sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=
 
-temp-file@^3.3.7:
+temp-file@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/temp-file/-/temp-file-3.4.0.tgz#766ea28911c683996c248ef1a20eea04d51652c7"
   integrity sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==
@@ -20472,11 +20695,6 @@ term-size@^1.2.0:
   integrity sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=
   dependencies:
     execa "^0.7.0"
-
-term-size@^2.1.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.1.tgz#2a6a54840432c2fb6320fea0f415531e90189f54"
-  integrity sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==
 
 terminal-link@^2.0.0:
   version "2.1.1"
@@ -20691,6 +20909,13 @@ tinycolor2@^1.4.1:
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.2.tgz#3f6a4d1071ad07676d7fa472e1fac40a719d8803"
   integrity sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==
 
+tmp-promise@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.3.tgz#60a1a1cc98c988674fcbfd23b6e3367bdeac4ce7"
+  integrity sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==
+  dependencies:
+    tmp "^0.2.0"
+
 tmp@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
@@ -20704,6 +20929,13 @@ tmp@^0.0.33:
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
     os-tmpdir "~1.0.2"
+
+tmp@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+  dependencies:
+    rimraf "^3.0.0"
 
 tmpl@1.0.x:
   version "1.0.4"
@@ -20929,6 +21161,11 @@ type-fest@^0.18.0:
   version "0.18.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.18.1.tgz#db4bc151a4a2cf4eebf9add5db75508db6cc841f"
   integrity sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==
+
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
 type-fest@^0.21.3:
   version "0.21.3"
@@ -21235,22 +21472,23 @@ update-notifier@^2.5.0:
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
 
-update-notifier@^4.1.0:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-4.1.3.tgz#be86ee13e8ce48fb50043ff72057b5bd598e1ea3"
-  integrity sha512-Yld6Z0RyCYGB6ckIjffGOSOmHXj1gMeE7aROz4MG+XMkmixBX4jUngrGXNYz7wPKBmtoD4MnBa2Anu7RSKht/A==
+update-notifier@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-5.1.0.tgz#4ab0d7c7f36a231dd7316cf7729313f0214d9ad9"
+  integrity sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==
   dependencies:
-    boxen "^4.2.0"
-    chalk "^3.0.0"
+    boxen "^5.0.0"
+    chalk "^4.1.0"
     configstore "^5.0.1"
     has-yarn "^2.1.0"
     import-lazy "^2.1.0"
     is-ci "^2.0.0"
-    is-installed-globally "^0.3.1"
-    is-npm "^4.0.0"
+    is-installed-globally "^0.4.0"
+    is-npm "^5.0.0"
     is-yarn-global "^0.3.0"
-    latest-version "^5.0.0"
-    pupa "^2.0.1"
+    latest-version "^5.1.0"
+    pupa "^2.1.1"
+    semver "^7.3.4"
     semver-diff "^3.1.1"
     xdg-basedir "^4.0.0"
 
@@ -21507,6 +21745,15 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+verror@^1.10.0:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.1.tgz#4bf09eeccf4563b109ed4b3d458380c972b0cdeb"
+  integrity sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==
+  dependencies:
+    assert-plus "^1.0.0"
+    core-util-is "1.0.2"
+    extsprintf "^1.2.0"
+
 vlq@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-1.0.1.tgz#c003f6e7c0b4c1edd623fd6ee50bbc0d6a1de468"
@@ -21594,8 +21841,10 @@ watchpack@^1.6.1, watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
@@ -22372,6 +22621,11 @@ xmlbuilder@8.2.2:
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-8.2.2.tgz#69248673410b4ba42e1a6136551d2922335aa773"
   integrity sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=
 
+xmlbuilder@>=11.0.1:
+  version "15.1.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-15.1.1.tgz#9dcdce49eea66d8d10b42cae94a79c3c8d0c2ec5"
+  integrity sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==
+
 xmlbuilder@^14.0.0:
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-14.0.0.tgz#876b5aec4f05ffd5feb97b0a871c855d16fbeb8c"
@@ -22626,6 +22880,19 @@ yargs@^16.1.1, yargs@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
+
+yargs@^17.0.1:
+  version "17.2.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.2.1.tgz#e2c95b9796a0e1f7f3bf4427863b42e0418191ea"
+  integrity sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==
   dependencies:
     cliui "^7.0.2"
     escalade "^3.1.1"


### PR DESCRIPTION
## Description 

- upgraded electron-builder version so it would work on m1 mac (main change is this [packages/rnv-engine-rn-electron/package.json](https://github.com/pavjacko/renative/compare/fix/rn-electron?expand=1#diff-ef8eeaa3c93b9d229ead6d5eb1c8167b979ab6a1146dc72a9f81f1b7595f04c7))
