### PR TITLE
added env variables debug with -i

### DIFF
--- a/packages/rnv/src/core/systemManager/exec.js
+++ b/packages/rnv/src/core/systemManager/exec.js
@@ -51,6 +51,8 @@ const _execute = (c, command, opts = {}) => {
 
     const mergedOpts = { ...defaultOpts, ...opts };
 
+    const env = opts.env && c.program.info ? Object.keys(opts.env).map(k => `${k}=${opts.env[k]}`).join(' ') : null;
+
     let cleanCommand = command;
     let interval;
     const intervalTimer = 30000; // 30s
@@ -70,6 +72,7 @@ const _execute = (c, command, opts = {}) => {
         );
     }
 
+    logMessage = `${env ? `${env} ` : ''}${logMessage}`;
     logDebug(`_execute: ${logMessage}`);
     const { silent, mono, maxErrorLength, ignoreErrors } = mergedOpts;
     const spinner = !silent && !mono && ora({ text: `Executing: ${logMessage}` }).start();


### PR DESCRIPTION
## Description 

- Describe the nature of the work / fix

## Breaking Changes

- PRs should not introduce breaking changes to existing functionality 
- if breaking change cannot be avoided it has to be introduced in 2 phases (release cycles of 0.x.0)
    - `0.x.0` Add new functionality + add `DEPRECATED` warning to existing fuctionality
    - `0.[x+1].0` Remove deprecated functionality
    
 ## I have tested my changes on:
 
 ReNative project directly:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

New project:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

Existing Project created with previous version of renative:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] web -e next browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
